### PR TITLE
chore: lint fixes for standard

### DIFF
--- a/test/Admin.ts/Trackgroups.test.js
+++ b/test/Admin.ts/Trackgroups.test.js
@@ -8,13 +8,13 @@ describe('Admin.ts/trackgroups endpoint test', () => {
   let response = null
 
   it('should handle no authentication', async () => {
-    response = await request.get(`/user/admin/trackgroups/`)
+    response = await request.get('/user/admin/trackgroups/')
 
     expect(response.status).to.eql(401)
   })
 
   it('should get all trackgroups', async () => {
-    response = await request.get(`/user/admin/trackgroups/`)
+    response = await request.get('/user/admin/trackgroups/')
 
     expect(response.status).to.eql(200)
 

--- a/test/Admin.ts/Tracks.test.js
+++ b/test/Admin.ts/Tracks.test.js
@@ -5,12 +5,12 @@ describe('Admin.ts/tracks endpoint test', () => {
   let response = null
 
   it('should handle no authentication', async () => {
-    response = await request.get(`/user/admin/trackgroups/`)
+    response = await request.get('/user/admin/trackgroups/')
 
     expect(response.status).to.eql(401)
   })
   it('should get all tracks', async () => {
-    response = await request.get(`/user/admin/tracks/`)
+    response = await request.get('/user/admin/tracks/')
 
     expect(response.status).to.eql(200)
 

--- a/test/Admin.ts/Users.test.js
+++ b/test/Admin.ts/Users.test.js
@@ -1,11 +1,11 @@
 
-const { request, expect, testUserId } = require('../testConfig')
+const { request, expect } = require('../testConfig')
 
 describe('Admin.ts/users endpoint test', () => {
   let response = null
 
   it('should get users', async () => {
-    response = await request.get(`/user/admin/users/`)
+    response = await request.get('/user/admin/users/')
 
     expect(response.status).to.eql(200)
 
@@ -25,7 +25,7 @@ describe('Admin.ts/users endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user by id', async () => {
-    response = await request.get(`/user/admin/users/$testUserId}`)
+    response = await request.get('/user/admin/users/$testUserId}')
 
     expect(response.status).to.eql(200)
 

--- a/test/Api.ts/Artists.test.js
+++ b/test/Api.ts/Artists.test.js
@@ -1,28 +1,28 @@
-
+/* eslint-disable no-unused-expressions */
 const { request, expect, testArtistId } = require('../testConfig')
 
 describe('Api.ts/artists endpoint test', () => {
   let response = null
 
   it('should get all artists', async () => {
-    response = await request.get(`/artists`)
+    response = await request.get('/artists')
 
     expect(response.status).to.eql(200)
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data", "count", "pages", "status")
+    expect(attributes).to.include.keys('data', 'count', 'pages', 'status')
 
     expect(attributes.data).to.be.an('array')
     expect(attributes.data.length).to.eql(1)
 
     const theData = attributes.data[0]
     //  FIXME: there is 'addressId' and 'AddressId'
-    expect(theData).to.include.keys("id", "ownerId", "typeId", "displayName", "description", "shortBio", "email", "addressId", "updatedAt", "createdAt", "deletedAt", "AddressId", "TrackGroups")
-    expect(theData.id).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theData.ownerId).to.eql("17203153-e2b0-457f-929d-5abe4e322ea1")
+    expect(theData).to.include.keys('id', 'ownerId', 'typeId', 'displayName', 'description', 'shortBio', 'email', 'addressId', 'updatedAt', 'createdAt', 'deletedAt', 'AddressId', 'TrackGroups')
+    expect(theData.id).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theData.ownerId).to.eql('17203153-e2b0-457f-929d-5abe4e322ea1')
     expect(theData.typeId).to.eql(1)
-    expect(theData.displayName).to.eql("capacitor")
+    expect(theData.displayName).to.eql('capacitor')
     expect(theData.description).to.be.null
     expect(theData.shortBio).to.be.null
     expect(theData.email).to.be.null
@@ -34,29 +34,29 @@ describe('Api.ts/artists endpoint test', () => {
 
     const theTG = theData.TrackGroups[0]
 
-    expect(theTG).to.include.keys("composers", "performers", "tags", "id", "cover", "title", "slug", "type", "about", "private", "display_artist", "creatorId",
-      "release_date", "download", "featured", "enabled", "updatedAt", "createdAt", "deletedAt", "items")
+    expect(theTG).to.include.keys('composers', 'performers', 'tags', 'id', 'cover', 'title', 'slug', 'type', 'about', 'private', 'display_artist', 'creatorId',
+      'release_date', 'download', 'featured', 'enabled', 'updatedAt', 'createdAt', 'deletedAt', 'items')
     expect(theTG.composers).to.be.an('array')
     expect(theTG.composers.length).to.eql(0)
     expect(theTG.performers).to.be.an('array')
     expect(theTG.performers.length).to.eql(0)
     expect(theTG.tags).to.be.an('array')
     expect(theTG.tags.length).to.eql(0)
-    expect(theTG.id).to.eql("c91bf101-2d3d-4181-8010-627ecce476de")
+    expect(theTG.id).to.eql('c91bf101-2d3d-4181-8010-627ecce476de')
     expect(theTG.cover).to.be.null
-    expect(theTG.title).to.eql("Best album ever")
+    expect(theTG.title).to.eql('Best album ever')
     expect(theTG.slug).to.be.null
-    expect(theTG.type).to.eql("lp")
-    expect(theTG.about).to.eql("this is the best album")
+    expect(theTG.type).to.eql('lp')
+    expect(theTG.about).to.eql('this is the best album')
     expect(theTG.private).to.be.false
-    expect(theTG.display_artist).to.eql("Jack")
-    expect(theTG.creatorId).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theTG.release_date).to.eql("2019-01-01")
+    expect(theTG.display_artist).to.eql('Jack')
+    expect(theTG.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theTG.release_date).to.eql('2019-01-01')
     expect(theTG.download).to.be.false
     expect(theTG.featured).to.be.false
     expect(theTG.enabled).to.be.null
-    expect(theTG.updatedAt).to.eql("2022-09-20T14:53:35.763Z")
-    expect(theTG.createdAt).to.eql("2022-09-20T14:53:35.763Z")
+    expect(theTG.updatedAt).to.eql('2022-09-20T14:53:35.763Z')
+    expect(theTG.createdAt).to.eql('2022-09-20T14:53:35.763Z')
     expect(theTG.deletedAt).to.be.null
 
     expect(theTG.items).to.be.an('array')
@@ -65,23 +65,23 @@ describe('Api.ts/artists endpoint test', () => {
     const theItem = theTG.items[0]
 
     expect(theItem).to.be.an('object')
-    expect(theItem).to.include.keys("id", "index", "track_id", "track")
-    expect(theItem.id).to.eql("e619e3f8-32c1-41c2-a9b1-314976e9a368")
+    expect(theItem).to.include.keys('id', 'index', 'track_id', 'track')
+    expect(theItem.id).to.eql('e619e3f8-32c1-41c2-a9b1-314976e9a368')
     expect(theItem.index).to.eql(1)
-    expect(theItem.track_id).to.eql("dd6c606c-0178-4887-8735-d3f84048c521")
+    expect(theItem.track_id).to.eql('dd6c606c-0178-4887-8735-d3f84048c521')
 
     expect(theItem.track).to.be.an('object')
     const theTrack = theItem.track
 
-    expect(theTrack).to.include.keys("status", "id", "legacyId", "creatorId", "title", "artist", "album", "album_artist", "composer", "year",
-      "url", "cover_art", "number", "tags", "updatedAt", "createdAt", "deletedAt", "track_url", "track_cover_art")
-    expect(theTrack.status).to.eql("free")
-    expect(theTrack.id).to.eql("dd6c606c-0178-4887-8735-d3f84048c521")
+    expect(theTrack).to.include.keys('status', 'id', 'legacyId', 'creatorId', 'title', 'artist', 'album', 'album_artist', 'composer', 'year',
+      'url', 'cover_art', 'number', 'tags', 'updatedAt', 'createdAt', 'deletedAt', 'track_url', 'track_cover_art')
+    expect(theTrack.status).to.eql('free')
+    expect(theTrack.id).to.eql('dd6c606c-0178-4887-8735-d3f84048c521')
     expect(theTrack.legacyId).to.be.null
-    expect(theTrack.creatorId).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theTrack.title).to.eql("De-engineered bottom-line migration")
-    expect(theTrack.artist).to.eql("Jared Blick")
-    expect(theTrack.album).to.eql("application")
+    expect(theTrack.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theTrack.title).to.eql('De-engineered bottom-line migration')
+    expect(theTrack.artist).to.eql('Jared Blick')
+    expect(theTrack.album).to.eql('application')
     expect(theTrack.album_artist).to.be.null
     expect(theTrack.composer).to.be.null
     expect(theTrack.year).to.be.null
@@ -89,8 +89,8 @@ describe('Api.ts/artists endpoint test', () => {
     expect(theTrack.cover_art).to.be.null
     expect(theTrack.number).to.be.null
     expect(theTrack.tags).to.be.null
-    expect(theTrack.updatedAt).to.eql("2022-09-20T14:53:35.794Z")
-    expect(theTrack.createdAt).to.eql("2022-09-20T14:53:35.794Z")
+    expect(theTrack.updatedAt).to.eql('2022-09-20T14:53:35.794Z')
+    expect(theTrack.createdAt).to.eql('2022-09-20T14:53:35.794Z')
     expect(theTrack.deletedAt).to.be.null
     expect(theTrack.track_url).to.be.null
     expect(theTrack.track_cover_art).to.be.null
@@ -106,17 +106,17 @@ describe('Api.ts/artists endpoint test', () => {
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data")
+    expect(attributes).to.include.keys('data')
 
     expect(attributes.data).to.be.an('object')
 
     const theData = attributes.data
     //  FIXME: there is 'addressId' and 'AddressId'
-    expect(theData).to.include.keys("id", "ownerId", "typeId", "displayName", "description", "shortBio", "email", "addressId", "updatedAt", "createdAt", "deletedAt", "AddressId", "User")
-    expect(theData.id).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theData.ownerId).to.eql("17203153-e2b0-457f-929d-5abe4e322ea1")
+    expect(theData).to.include.keys('id', 'ownerId', 'typeId', 'displayName', 'description', 'shortBio', 'email', 'addressId', 'updatedAt', 'createdAt', 'deletedAt', 'AddressId', 'User')
+    expect(theData.id).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theData.ownerId).to.eql('17203153-e2b0-457f-929d-5abe4e322ea1')
     expect(theData.typeId).to.eql(1)
-    expect(theData.displayName).to.eql("capacitor")
+    expect(theData.displayName).to.eql('capacitor')
     expect(theData.description).to.be.null
     expect(theData.shortBio).to.be.null
     expect(theData.email).to.be.null
@@ -124,9 +124,9 @@ describe('Api.ts/artists endpoint test', () => {
     expect(theData.AddressId).to.be.null
 
     expect(theData.User).to.be.an('object')
-    expect(theData.User).to.include.keys("id", "displayName")
-    expect(theData.User.id).to.eql("17203153-e2b0-457f-929d-5abe4e322ea1")
-    expect(theData.User.displayName).to.eql("artist")
+    expect(theData.User).to.include.keys('id', 'displayName')
+    expect(theData.User.id).to.eql('17203153-e2b0-457f-929d-5abe4e322ea1')
+    expect(theData.User.displayName).to.eql('artist')
   })
   it('should get an artist\'s releases by artist id', async () => {
     response = await request.get(`/artists/${testArtistId}/releases`)
@@ -135,53 +135,53 @@ describe('Api.ts/artists endpoint test', () => {
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    expect(attributes).to.include.keys('data', 'count', 'numberOfPages', 'status')
 
     expect(attributes.data).to.be.an('array')
     expect(attributes.data.length).to.eql(1)
 
     const theData = attributes.data[0]
 
-    expect(theData).to.include.keys("tags", "about", "cover", "creatorId", "display_artist", "id", "slug", "title", "createdAt", "release_date", "type",
-      "cover_metadata", "userGroup", "items")
+    expect(theData).to.include.keys('tags', 'about', 'cover', 'creatorId', 'display_artist', 'id', 'slug', 'title', 'createdAt', 'release_date', 'type',
+      'cover_metadata', 'userGroup', 'items')
     expect(theData.tags).to.be.an('array')
     expect(theData.tags.length).to.eql(0)
-    expect(theData.about).to.eql("this is the best album2")
+    expect(theData.about).to.eql('this is the best album2')
     expect(theData.cover).to.be.null
-    expect(theData.creatorId).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theData.display_artist).to.eql("Jill")
-    expect(theData.id).to.eql("5e2a28a8-d767-4b94-9a16-a6403848b512")
-    expect(theData.slug).to.eql("best-album-ever-2")
-    expect(theData.title).to.eql("Best album ever 2")
-    expect(theData.createdAt).to.eql("2022-09-20T14:53:35.763Z")
-    expect(theData.release_date).to.eql("2019-01-01")
-    expect(theData.type).to.eql("lp")
+    expect(theData.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theData.display_artist).to.eql('Jill')
+    expect(theData.id).to.eql('5e2a28a8-d767-4b94-9a16-a6403848b512')
+    expect(theData.slug).to.eql('best-album-ever-2')
+    expect(theData.title).to.eql('Best album ever 2')
+    expect(theData.createdAt).to.eql('2022-09-20T14:53:35.763Z')
+    expect(theData.release_date).to.eql('2019-01-01')
+    expect(theData.type).to.eql('lp')
     expect(theData.cover_metadata).to.be.null
 
     expect(theData.userGroup).to.be.an('object')
-    expect(theData.userGroup).to.include.keys("id", "displayName")
-    expect(theData.userGroup.id).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theData.userGroup.displayName).to.eql("capacitor")
+    expect(theData.userGroup).to.include.keys('id', 'displayName')
+    expect(theData.userGroup.id).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theData.userGroup.displayName).to.eql('capacitor')
 
     expect(theData.items).to.be.an('array')
     expect(theData.items.length).to.eql(10)
 
     const theItem = theData.items[0]
-    expect(theItem).to.include.keys("id", "index", 'track_id', "track")
-    expect(theItem.id).to.eql("c688036b-658b-467e-8188-831e78eeba9b")
+    expect(theItem).to.include.keys('id', 'index', 'track_id', 'track')
+    expect(theItem.id).to.eql('c688036b-658b-467e-8188-831e78eeba9b')
     expect(theItem.index).to.eql(1)
-    expect(theItem.track_id).to.eql("cd62b193-2faa-45a4-9afa-36e09305d507")
+    expect(theItem.track_id).to.eql('cd62b193-2faa-45a4-9afa-36e09305d507')
 
     const theTrack = theItem.track
-    expect(theTrack).to.include.keys("status", "id", "legacyId", "creatorId", "title", "artist", "album", "album_artist", "composer", "year", "url", "cover_art",
-      "number", "tags", "updatedAt", "createdAt", "deletedAt", "track_url", "track_cover_art")
-    expect(theTrack.status).to.eql("free")
-    expect(theTrack.id).to.eql("cd62b193-2faa-45a4-9afa-36e09305d507")
+    expect(theTrack).to.include.keys('status', 'id', 'legacyId', 'creatorId', 'title', 'artist', 'album', 'album_artist', 'composer', 'year', 'url', 'cover_art',
+      'number', 'tags', 'updatedAt', 'createdAt', 'deletedAt', 'track_url', 'track_cover_art')
+    expect(theTrack.status).to.eql('free')
+    expect(theTrack.id).to.eql('cd62b193-2faa-45a4-9afa-36e09305d507')
     expect(theTrack.legacyId).to.be.null
-    expect(theTrack.creatorId).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theTrack.title).to.eql("Seamless bi-directional conglomeration")
-    expect(theTrack.artist).to.eql("Susan Ankunding")
-    expect(theTrack.album).to.eql("program")
+    expect(theTrack.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theTrack.title).to.eql('Seamless bi-directional conglomeration')
+    expect(theTrack.artist).to.eql('Susan Ankunding')
+    expect(theTrack.album).to.eql('program')
     expect(theTrack.album_artist).to.be.null
     expect(theTrack.composer).to.be.null
     expect(theTrack.year).to.be.null
@@ -189,8 +189,8 @@ describe('Api.ts/artists endpoint test', () => {
     expect(theTrack.cover_art).to.be.null
     expect(theTrack.number).to.null
     expect(theTrack.tags).to.be.null
-    expect(theTrack.updatedAt).to.eql("2022-09-20T14:53:35.797Z")
-    expect(theTrack.createdAt).to.eql("2022-09-20T14:53:35.797Z")
+    expect(theTrack.updatedAt).to.eql('2022-09-20T14:53:35.797Z')
+    expect(theTrack.createdAt).to.eql('2022-09-20T14:53:35.797Z')
     expect(theTrack.deletedAt).to.be.null
     expect(theTrack.track_url).to.be.null
     expect(theTrack.track_cover_art).to.be.null
@@ -207,30 +207,30 @@ describe('Api.ts/artists endpoint test', () => {
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data")
+    expect(attributes).to.include.keys('data')
 
     const theData = attributes.data
     expect(theData).to.be.an('array')
     expect(theData.length).to.eql(1)
 
     const theItem = theData[0]
-    expect(theItem).to.include.keys("id", "title", "album", "cover_metadata", "artist", "status", "url", "images")
+    expect(theItem).to.include.keys('id', 'title', 'album', 'cover_metadata', 'artist', 'status', 'url', 'images')
 
-    expect(theItem.id).to.eql("b6d160d1-be16-48a4-8c4f-0c0574c4c6aa")
-    expect(theItem.title).to.eql("Organized empowering success")
-    expect(theItem.album).to.eql("driver")
+    expect(theItem.id).to.eql('b6d160d1-be16-48a4-8c4f-0c0574c4c6aa')
+    expect(theItem.title).to.eql('Organized empowering success')
+    expect(theItem.album).to.eql('driver')
 
     expect(theItem.cover_metadata).to.be.an('object')
-    expect(theItem.cover_metadata).to.include.keys("id")
+    expect(theItem.cover_metadata).to.include.keys('id')
     expect(theItem.cover_metadata.id).to.be.null
 
-    expect(theItem.artist).to.eql("capacitor")
-    expect(theItem.status).to.eql("Paid")
-    expect(theItem.url).to.eql("https://beta.stream.resonate.localhost/api/v3/user/stream/b6d160d1-be16-48a4-8c4f-0c0574c4c6aa")
+    expect(theItem.artist).to.eql('capacitor')
+    expect(theItem.status).to.eql('Paid')
+    expect(theItem.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/b6d160d1-be16-48a4-8c4f-0c0574c4c6aa')
 
     expect(theItem.images).to.be.an('object')
-    expect(theItem.images).to.include.keys("small", "medium")
-    expect(theItem.images.small).to.include.keys("width", "height")
+    expect(theItem.images).to.include.keys('small', 'medium')
+    expect(theItem.images.small).to.include.keys('width', 'height')
     expect(theItem.images.small.width).to.eql(120)
     expect(theItem.images.small.height).to.eql(120)
     expect(theItem.images.medium.width).to.eql(600)

--- a/test/Api.ts/Labels.test.js
+++ b/test/Api.ts/Labels.test.js
@@ -4,9 +4,8 @@ const { request, expect, testLabelId } = require('../testConfig')
 describe('Api.ts/labels endpoint test', () => {
   let response = null
 
-
   it.only('should get all labels', async () => {
-    response = await request.get(`/labels`)
+    response = await request.get('/labels')
 
     // relation \"rsntr_users\" does not exist"
 
@@ -26,7 +25,6 @@ describe('Api.ts/labels endpoint test', () => {
     // expect(attributes.count).to.eql(1)
     // expect(attributes.numberOfPages).to.eql(1)
     // expect(attributes.status).to.eql('ok')
-
   })
   it('should get a label by id', async () => {
     response = await request.get(`/labels/${testLabelId}`)
@@ -47,7 +45,6 @@ describe('Api.ts/labels endpoint test', () => {
     // expect(attributes.count).to.eql(1)
     // expect(attributes.numberOfPages).to.eql(1)
     // expect(attributes.status).to.eql('ok')
-
   })
   it('should a label\'s releases by label id', async () => {
     response = await request.get(`/labels/${testLabelId}/releases`)
@@ -68,7 +65,6 @@ describe('Api.ts/labels endpoint test', () => {
     // expect(attributes.count).to.eql(1)
     // expect(attributes.numberOfPages).to.eql(1)
     // expect(attributes.status).to.eql('ok')
-
   })
   it('should get a label\'s artists by label id', async () => {
     response = await request.get(`/labels/${testLabelId}/artists`)
@@ -89,7 +85,6 @@ describe('Api.ts/labels endpoint test', () => {
     // expect(attributes.count).to.eql(1)
     // expect(attributes.numberOfPages).to.eql(1)
     // expect(attributes.status).to.eql('ok')
-
   })
   it('should get a label\'s albums by label id', async () => {
     response = await request.get(`/labels/${testLabelId}/albums`)
@@ -110,6 +105,5 @@ describe('Api.ts/labels endpoint test', () => {
     // expect(attributes.count).to.eql(1)
     // expect(attributes.numberOfPages).to.eql(1)
     // expect(attributes.status).to.eql('ok')
-
   })
 })

--- a/test/Api.ts/Search.test.js
+++ b/test/Api.ts/Search.test.js
@@ -5,12 +5,12 @@ describe('Api.ts/search endpoint test', () => {
   let response = null
 
   it('should handle no provided search term/s', async () => {
-    response = await request.get(`/search`)
+    response = await request.get('/search')
 
     expect(response.status).to.eql(400)
   })
   it('should return results for a search term', async () => {
-    let searchTerm = 'asdf'
+    const searchTerm = 'asdf'
 
     response = await request.get(`/search?q=${searchTerm}`)
 

--- a/test/Api.ts/Tag.test.js
+++ b/test/Api.ts/Tag.test.js
@@ -11,7 +11,7 @@ describe('Api.ts/tag endpoint test', () => {
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("id", "type", "name")
+    expect(attributes).to.include.keys('id', 'type', 'name')
 
     // expect(attributes.data).to.be.an('array')
     // expect(attributes.data.length).to.be.greaterThan(0)
@@ -23,6 +23,5 @@ describe('Api.ts/tag endpoint test', () => {
     // expect(attributes.count).to.eql(1)
     // expect(attributes.numberOfPages).to.eql(1)
     // expect(attributes.status).to.eql('ok')
-
   })
 })

--- a/test/Api.ts/Trackgroups.test.js
+++ b/test/Api.ts/Trackgroups.test.js
@@ -1,26 +1,26 @@
-
+/* eslint-disable no-unused-expressions */
 const { request, expect, testTrackGroupId } = require('../testConfig')
 
 describe('Api.ts/Trackgroups endpoint test', () => {
   let response = null
 
   it('should get all trackgroups', async () => {
-    response = await request.get(`/trackgroups`)
+    response = await request.get('/trackgroups')
 
     expect(response.status).to.eql(200)
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    expect(attributes).to.include.keys('data', 'count', 'numberOfPages', 'status')
 
     expect(attributes.data).to.be.an('array')
-    expect(attributes.data.length).to.eql(3)    // there are three in the base track_groups table
+    expect(attributes.data.length).to.eql(3) // there are three in the base track_groups table
 
     const theData = attributes.data[0]
-    expect(theData).to.include.keys("about", "creatorId", "display_artist", "id", "slug", "tags", "title", "type", "cover_metadata", "userGroup", "uri", "images")
+    expect(theData).to.include.keys('about', 'creatorId', 'display_artist', 'id', 'slug', 'tags', 'title', 'type', 'cover_metadata', 'userGroup', 'uri', 'images')
     expect(theData.about).to.eql('this is the best album2')
-    expect(theData.creatorId).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theData.display_artist).to.eql("Jill")
+    expect(theData.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theData.display_artist).to.eql('Jill')
     expect(theData.id).to.eql('5e2a28a8-d767-4b94-9a16-a6403848b512')
     expect(theData.slug).to.eql('best-album-ever-2')
     expect(theData.tags).to.be.an('array')
@@ -29,20 +29,20 @@ describe('Api.ts/Trackgroups endpoint test', () => {
     expect(theData.type).to.eql('lp')
     expect(theData.cover_metadata).to.be.null
 
-    expect(theData.userGroup).to.include.keys("id", "displayName")
-    expect(theData.userGroup.id).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
+    expect(theData.userGroup).to.include.keys('id', 'displayName')
+    expect(theData.userGroup.id).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
     expect(theData.userGroup.displayName).to.eql('capacitor')
 
-    expect(theData.uri).to.eql("http://localhost:4000/v3/trackgroups/5e2a28a8-d767-4b94-9a16-a6403848b512")
+    expect(theData.uri).to.eql('http://localhost:4000/v3/trackgroups/5e2a28a8-d767-4b94-9a16-a6403848b512')
 
-    expect(theData.images).to.include.keys("small", "medium", "large")
-    expect(theData.images.small).to.include.keys("width", "height")
+    expect(theData.images).to.include.keys('small', 'medium', 'large')
+    expect(theData.images.small).to.include.keys('width', 'height')
     expect(theData.images.small.width).to.eql(120)
     expect(theData.images.small.height).to.eql(120)
-    expect(theData.images.medium).to.include.keys("width", "height")
+    expect(theData.images.medium).to.include.keys('width', 'height')
     expect(theData.images.medium.width).to.eql(600)
     expect(theData.images.medium.height).to.eql(600)
-    expect(theData.images.large).to.include.keys("width", "height")
+    expect(theData.images.large).to.include.keys('width', 'height')
     expect(theData.images.large.width).to.eql(1500)
     expect(theData.images.large.height).to.eql(1500)
 
@@ -52,7 +52,7 @@ describe('Api.ts/Trackgroups endpoint test', () => {
   })
 
   it('should handle request with non-existent id', async () => {
-    response = await request.get(`/trackgroups/asdf`)
+    response = await request.get('/trackgroups/asdf')
 
     expect(response.status).to.eql(400)
   })
@@ -64,16 +64,16 @@ describe('Api.ts/Trackgroups endpoint test', () => {
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    expect(attributes).to.include.keys('data', 'count', 'numberOfPages', 'status')
 
     expect(attributes.data).to.be.an('array')
-    expect(attributes.data.length).to.eql(3)    // there are three in the track_groups table
+    expect(attributes.data.length).to.eql(3) // there are three in the track_groups table
 
     const theData = attributes.data[0]
-    expect(theData).to.include.keys("about", "creatorId", "display_artist", "id", "slug", "tags", "title", "type", "cover_metadata", "userGroup", "uri", "images")
+    expect(theData).to.include.keys('about', 'creatorId', 'display_artist', 'id', 'slug', 'tags', 'title', 'type', 'cover_metadata', 'userGroup', 'uri', 'images')
     expect(theData.about).to.eql('this is the best album2')
-    expect(theData.creatorId).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
-    expect(theData.display_artist).to.eql("Jill")
+    expect(theData.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
+    expect(theData.display_artist).to.eql('Jill')
     expect(theData.id).to.eql('5e2a28a8-d767-4b94-9a16-a6403848b512')
     expect(theData.slug).to.eql('best-album-ever-2')
     expect(theData.tags).to.be.an('array')
@@ -82,20 +82,20 @@ describe('Api.ts/Trackgroups endpoint test', () => {
     expect(theData.type).to.eql('lp')
     expect(theData.cover_metadata).to.be.null
 
-    expect(theData.userGroup).to.include.keys("id", "displayName")
-    expect(theData.userGroup.id).to.eql("251c01f6-7293-45f6-b8cd-242bdd76cd0d")
+    expect(theData.userGroup).to.include.keys('id', 'displayName')
+    expect(theData.userGroup.id).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
     expect(theData.userGroup.displayName).to.eql('capacitor')
 
-    expect(theData.uri).to.eql("http://localhost:4000/v3/trackgroups/5e2a28a8-d767-4b94-9a16-a6403848b512")
+    expect(theData.uri).to.eql('http://localhost:4000/v3/trackgroups/5e2a28a8-d767-4b94-9a16-a6403848b512')
 
-    expect(theData.images).to.include.keys("small", "medium", "large")
-    expect(theData.images.small).to.include.keys("width", "height")
+    expect(theData.images).to.include.keys('small', 'medium', 'large')
+    expect(theData.images.small).to.include.keys('width', 'height')
     expect(theData.images.small.width).to.eql(120)
     expect(theData.images.small.height).to.eql(120)
-    expect(theData.images.medium).to.include.keys("width", "height")
+    expect(theData.images.medium).to.include.keys('width', 'height')
     expect(theData.images.medium.width).to.eql(600)
     expect(theData.images.medium.height).to.eql(600)
-    expect(theData.images.large).to.include.keys("width", "height")
+    expect(theData.images.large).to.include.keys('width', 'height')
     expect(theData.images.large.width).to.eql(1500)
     expect(theData.images.large.height).to.eql(1500)
 

--- a/test/Api.ts/Tracks.test.js
+++ b/test/Api.ts/Tracks.test.js
@@ -1,5 +1,4 @@
-
-
+/* eslint-disable no-unused-expressions */
 const { request, expect, testTrackId } = require('../testConfig')
 
 describe('Api.ts/track endpoint test', () => {
@@ -8,36 +7,36 @@ describe('Api.ts/track endpoint test', () => {
   //  GET /tracks/${options.order !== "random" ? "latest" : ""}
 
   it('should get tracks when options.order is not \'random\'', async () => {
-    response = await request.get(`/tracks/latest`)
+    response = await request.get('/tracks/latest')
 
     expect(response.status).to.eql(200)
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data", "count", "numberOfPages")
+    expect(attributes).to.include.keys('data', 'count', 'numberOfPages')
 
     expect(attributes.data).to.be.an('array')
     expect(attributes.data.length).to.eql(10)
 
     //  FIXME: find a way to test all elements of data array. for now, just test the first one.
     const theData = attributes.data[0]
-    expect(theData).to.include.keys("id", "title", "album", "cover_metadata", "artist", "status", "url", "images")
-    expect(theData.id).to.eql("e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def")
-    expect(theData.title).to.eql("Universal 3rd generation hardware")
-    expect(theData.album).to.eql("hard drive")
+    expect(theData).to.include.keys('id', 'title', 'album', 'cover_metadata', 'artist', 'status', 'url', 'images')
+    expect(theData.id).to.eql('e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
+    expect(theData.title).to.eql('Universal 3rd generation hardware')
+    expect(theData.album).to.eql('hard drive')
 
-    expect(theData.cover_metadata).to.include.keys("id")
+    expect(theData.cover_metadata).to.include.keys('id')
     expect(theData.cover_metadata.id).to.be.null
 
     expect(theData.artist).to.be.null
     expect(theData.status).to.eql('Paid')
-    expect(theData.url).to.eql("https://beta.stream.resonate.localhost/api/v3/user/stream/e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def")
+    expect(theData.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
 
-    expect(theData.images).to.include.keys("small", "medium")
-    expect(theData.images.small).to.include.keys("width", "height")
+    expect(theData.images).to.include.keys('small', 'medium')
+    expect(theData.images.small).to.include.keys('width', 'height')
     expect(theData.images.small.width).to.eql(120)
     expect(theData.images.small.height).to.eql(120)
-    expect(theData.images.medium).to.include.keys("width", "height")
+    expect(theData.images.medium).to.include.keys('width', 'height')
     expect(theData.images.medium.width).to.eql(600)
     expect(theData.images.medium.height).to.eql(600)
 
@@ -46,7 +45,7 @@ describe('Api.ts/track endpoint test', () => {
   })
 
   it('should get tracks when options.order is \'random\'', async () => {
-    response = await request.get(`/tracks`)
+    response = await request.get('/tracks')
 
     expect(response.status).to.eql(200)
 
@@ -72,31 +71,31 @@ describe('Api.ts/track endpoint test', () => {
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("data")
+    expect(attributes).to.include.keys('data')
 
     expect(attributes.data).to.be.an('object')
 
     const theData = attributes.data
-    expect(theData).to.include.keys("id", "creatorId", "title", "album", "year", "artist", "cover_metadata", "status", "url", "images")
-    expect(theData.id).to.eql("e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def")
-    expect(theData.title).to.eql("Universal 3rd generation hardware")
-    expect(theData.album).to.eql("hard drive")
+    expect(theData).to.include.keys('id', 'creatorId', 'title', 'album', 'year', 'artist', 'cover_metadata', 'status', 'url', 'images')
+    expect(theData.id).to.eql('e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
+    expect(theData.title).to.eql('Universal 3rd generation hardware')
+    expect(theData.album).to.eql('hard drive')
 
-    expect(theData.cover_metadata).to.include.keys("id")
+    expect(theData.cover_metadata).to.include.keys('id')
     expect(theData.cover_metadata.id).to.be.null
 
     expect(theData.artist).to.eq; ('capacitor')
     expect(theData.status).to.eql('Paid')
-    expect(theData.url).to.eql("https://api.resonate.is/v1/stream/e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def")
+    expect(theData.url).to.eql('https://api.resonate.is/v1/stream/e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
 
-    expect(theData.images).to.include.keys("small", "medium", "large")
-    expect(theData.images.small).to.include.keys("width", "height")
+    expect(theData.images).to.include.keys('small', 'medium', 'large')
+    expect(theData.images.small).to.include.keys('width', 'height')
     expect(theData.images.small.width).to.eql(120)
     expect(theData.images.small.height).to.eql(120)
-    expect(theData.images.medium).to.include.keys("width", "height")
+    expect(theData.images.medium).to.include.keys('width', 'height')
     expect(theData.images.medium.width).to.eql(600)
     expect(theData.images.medium.height).to.eql(600)
-    expect(theData.images.large).to.include.keys("width", "height")
+    expect(theData.images.large).to.include.keys('width', 'height')
     expect(theData.images.large.width).to.eql(1500)
     expect(theData.images.large.height).to.eql(1500)
   })

--- a/test/Template.test.js
+++ b/test/Template.test.js
@@ -5,19 +5,19 @@ describe('TEMPLATE endpoint test', () => {
   let response = null
 
   it('should do something', async () => {
-    response = await request.get(`/`)
+    response = await request.get('/')
 
     expect(response.status).to.eql()
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys("")
+    expect(attributes).to.include.keys('')
 
     expect(attributes.data).to.be.an('array')
     expect(attributes.data.length).to.eql(3)
 
     const theData = attributes.data[0]
-    expect(theData).to.include.keys("")
+    expect(theData).to.include.keys('')
     expect(theData.xxx).to.eql()
 
     expect(attributes.count).to.eql(1)

--- a/test/User.ts/MiscUserInfo.test.js
+++ b/test/User.ts/MiscUserInfo.test.js
@@ -4,8 +4,8 @@ const { request, expect } = require('../testConfig')
 describe('User.ts/misc user info endpoint test', () => {
   let response = null
 
-  let from = '2020-01-01'
-  let to = '2020-12-31'
+  const from = '2020-01-01'
+  const to = '2020-12-31'
 
   it('should get user plays within date range', async () => {
     response = await request.get(`/user/plays/stats?from=${from}&to=${to}`)
@@ -28,7 +28,7 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user plays history artists (?)', async () => {
-    response = await request.get(`/user/plays/history/artists`)
+    response = await request.get('/user/plays/history/artists')
 
     expect(response.status).to.eql(200)
 
@@ -48,7 +48,7 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user collections', async () => {
-    response = await request.get(`/user/collection/`)
+    response = await request.get('/user/collection/')
 
     expect(response.status).to.eql(200)
 
@@ -68,7 +68,7 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user plays history', async () => {
-    response = await request.get(`/user/plays/history/`)
+    response = await request.get('/user/plays/history/')
 
     expect(response.status).to.eql(200)
 
@@ -88,7 +88,7 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user favorites', async () => {
-    response = await request.get(`/user/favorites`)
+    response = await request.get('/user/favorites')
 
     expect(response.status).to.eql(200)
 
@@ -108,7 +108,7 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user favorites (no user id? all of them?)', async () => {
-    response = await request.post(`/user/favorites`)
+    response = await request.post('/user/favorites')
 
     expect(response.status).to.eql(200)
 
@@ -128,7 +128,7 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user favorites resolve (?)', async () => {
-    response = await request.get(`/user/favorites/resolve`)
+    response = await request.get('/user/favorites/resolve')
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/Products.test.js
+++ b/test/User.ts/Products.test.js
@@ -5,7 +5,7 @@ describe('User.ts/products endpoint test', () => {
   let response = null
 
   it('should get user products', async () => {
-    response = await request.get(`/user/products`)
+    response = await request.get('/user/products')
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/User.test.js
+++ b/test/User.ts/User.test.js
@@ -7,7 +7,7 @@ describe('User.ts/user endpoint test', () => {
   let response = null
 
   it('should get user profiles', async () => {
-    response = await request.get(`/user/profile/`)
+    response = await request.get('/user/profile/')
 
     expect(response.status).to.eql(200)
 
@@ -47,7 +47,7 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user/trackgroups', async () => {
-    response = await request.post(`/user/trackgroups`)
+    response = await request.post('/user/trackgroups')
 
     expect(response.status).to.eql(200)
 
@@ -87,7 +87,7 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user trackgroups', async () => {
-    response = await request.get(`/user/trackgroups`)
+    response = await request.get('/user/trackgroups')
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/UserArtist.test.js
+++ b/test/User.ts/UserArtist.test.js
@@ -7,7 +7,7 @@ describe('User.ts/user artist endpoint test', () => {
   let response = null
 
   it('should get user artists', async () => {
-    response = await request.get(`/user/artists`)
+    response = await request.get('/user/artists')
 
     expect(response.status).to.eql(200)
 
@@ -47,7 +47,7 @@ describe('User.ts/user artist endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user artists', async () => {
-    response = await request.post(`/user/artists`)
+    response = await request.post('/user/artists')
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/UserPlays.test.js
+++ b/test/User.ts/UserPlays.test.js
@@ -5,7 +5,7 @@ describe('User.ts/user plays endpoint test', () => {
   let response = null
 
   it('should post to user plays (all of them?)', async () => {
-    response = await request.get(`/user/plays`)
+    response = await request.get('/user/plays')
 
     expect(response.status).to.eql(200)
 
@@ -25,7 +25,7 @@ describe('User.ts/user plays endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user plays buy', async () => {
-    response = await request.post(`/user/plays/buy`)
+    response = await request.post('/user/plays/buy')
 
     expect(response.status).to.eql(200)
 
@@ -45,7 +45,7 @@ describe('User.ts/user plays endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user plays resolve (?)', async () => {
-    response = await request.get(`/user/plays/resolve`)
+    response = await request.get('/user/plays/resolve')
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/UserTracks.test.js
+++ b/test/User.ts/UserTracks.test.js
@@ -1,11 +1,11 @@
 
-const { request, expect, testUserId, testTrackId, testTrackGroupId } = require('../testConfig')
+const { request, expect, testTrackId, testTrackGroupId } = require('../testConfig')
 
 describe('User.ts/user tracks endpoint test', () => {
   let response = null
 
   it('should post to user tracks', async () => {
-    response = await request.post(`/user/tracks`)
+    response = await request.post('/user/tracks')
 
     expect(response.status).to.eql(200)
 

--- a/test/testConfig.js
+++ b/test/testConfig.js
@@ -1,13 +1,13 @@
 
-const baseURL = "http://localhost:4000/api/v3"
+const baseURL = 'http://localhost:4000/api/v3'
 // const baseURL = "https://stream.resonate.coop/api/v3/"
 const request = require('supertest')(baseURL)
 
 // Do this to enable auth persistence
 //      https://stackoverflow.com/questions/14001183/how-to-authenticate-supertest-requests-with-passport
-const persistedRequest = require("supertest").agent(baseURL);
+const persistedRequest = require('supertest').agent(baseURL)
 
-const expect = require("chai").expect;
+const expect = require('chai').expect
 
 // test ids come from the yarn docker:seed:all command you should have already
 //    run as part of the api setup
@@ -15,8 +15,8 @@ const testUserId = '17203153-e2b0-457f-929d-5abe4e322ea1'
 const testTrackGroupId = 'c91bf101-2d3d-4181-8010-627ecce476de'
 const testTagId = 'asdf'
 const testLabelId = 'asdf'
-const testArtistId = "251c01f6-7293-45f6-b8cd-242bdd76cd0d"
-const testTrackId = "e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def"
+const testArtistId = '251c01f6-7293-45f6-b8cd-242bdd76cd0d'
+const testTrackId = 'e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def'
 
 const testAccessToken = 'asdf'
 


### PR DESCRIPTION
Putting in these lint ignore rules so that we can use mocha. 

See this stack overflow question: https://stackoverflow.com/questions/45079454/no-unused-expressions-in-mocha-chai-unit-test-using-standardjs