### PR TITLE
chore: replaced start-dev with start:dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY --from=ffmpeg / /
 
 EXPOSE 4000
 
-CMD ["yarn", "start-dev"]
+CMD ["yarn", "start:dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - api-network
       - redis-network
     build: .
-    command: /bin/sh -c "yarn && yarn migrate && yarn start-dev"
+    command: /bin/sh -c "yarn && yarn migrate && yarn start:dev"
     container_name: resonate-api
     environment:
       - NODE_ENV=development

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "gpl3",
   "private": true,
   "scripts": {
-    "start-dev": "./node_modules/nodemon/bin/nodemon.js --trace-warnings ./server.js --config nodemon.json",
+    "start:dev": "./node_modules/nodemon/bin/nodemon.js --trace-warnings ./server.js --config nodemon.json",
     "start": "node src/index.js",
     "migrate": "NODE_ENV=development sequelize db:migrate --config src/config/databases.js --migrations-path src/db/migrations",
     "docker:workers": "NODE_ENV=development docker exec -it resonate-api node src/jobs/queue-worker.js run",


### PR DESCRIPTION
found 6 instances of 'start-dev'. 

replaced with 'start:dev', to keep consistent with other script handles.