### PR TITLE
feat: tests run inside of docker. api tests complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .vscode
+resonate-api.code-workspace
 node_modules
 
 data

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,13 @@
+// Config for running Mocha in watch mode, inside of resonate api test Docker container
+
+// https://www.testim.io/blog/mocharc-configuration/
+// https://stackoverflow.com/questions/72479267/mocha-watch-with-docker
+
+module.exports = {
+    "reporter": "spec",
+    "watch": true,
+    "watch-files": ['test/**/*.js', 'src/**/*.js'],
+    "watch-ignore": ['node_modules'],
+    // "file": 'test/common.js',
+    "recursive": true
+};

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
     "docker:seed:all:test": "NODE_ENV=test docker exec -it resonate-api npx sequelize db:seed:all --config src/config/databases.js --seeders-path src/db/seeders/test",
     "docker:seed:undo:all:test": "NODE_ENV=test docker exec -it resonate-api npx sequelize db:seed:undo:all --config src/config/databases.js --seeders-path src/db/seeders/test",
     "lint": "standard",
-    "test": "mocha",
-    "test:watch": "mocha -w",
-    "test:api": "mocha test/Api.ts",
-    "test:admin": "mocha test/Admin.ts",
-    "test:user": "mocha test/User.ts"
+    "lint:fix": "standard --fix",
+    "test:api": "clear && docker exec -it resonate-api yarn mocha test/Api.ts",
+    "test:admin": "clear && docker exec -it resonate-api yarn mocha test/Admin.ts",
+    "test:user": "clear && docker exec -it resonate-api yarn mocha test/User.ts"
   },
   "dependencies": {
     "@koa/cors": "^3.1.0",

--- a/test/Admin.ts/Trackgroups.test.js
+++ b/test/Admin.ts/Trackgroups.test.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-// endpoints access token
-//    probably need the supertest persist whatever thing
 
-const { request, expect, testTrackGroupId, testAccessToken } = require('../testConfig')
+const { request, expect, testTrackGroupId, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('Admin.ts/trackgroups endpoint test', () => {
   require('../MockAccessToken')
@@ -12,6 +10,11 @@ describe('Admin.ts/trackgroups endpoint test', () => {
 
   it('should handle no authentication / accessToken', async () => {
     response = await request.get('/user/admin/trackgroups/')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/admin/trackgroups/').set('Authorization', `Bearer ${testInvalidAccessToken}`)
 
     expect(response.status).to.eql(401)
   })

--- a/test/Admin.ts/Tracks.test.js
+++ b/test/Admin.ts/Tracks.test.js
@@ -1,8 +1,11 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-const { request, expect, testTrackId } = require('../testConfig')
+
+const { request, expect, testTrackId, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('Admin.ts/tracks endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
   it('should handle no authentication', async () => {
@@ -10,9 +13,16 @@ describe('Admin.ts/tracks endpoint test', () => {
 
     expect(response.status).to.eql(401)
   })
-  it('should get all tracks', async () => {
-    response = await request.get('/user/admin/tracks/')
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/admin/trackgroups/').set('Authorization', `Bearer ${testInvalidAccessToken}`)
 
+    expect(response.status).to.eql(401)
+  })
+
+  it('should get all tracks', async () => {
+    response = await request.get('/user/admin/tracks/').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('all tracks RESPONSE: ', response.text)
     expect(response.status).to.eql(200)
 
     // const attributes = response.body
@@ -31,7 +41,9 @@ describe('Admin.ts/tracks endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get track by id', async () => {
-    response = await request.get(`/user/admin/tracks/${testTrackId}`)
+    response = await request.get(`/user/admin/tracks/${testTrackId}`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('track by id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -51,7 +63,9 @@ describe('Admin.ts/tracks endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should update a track by id', async () => {
-    response = await request.put(`/user/admin/tracks/${testTrackId}`)
+    response = await request.put(`/user/admin/tracks/${testTrackId}`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('update track by id RESPONSE: ', response.text)
 
     // check Admin.ts for interface / type for payload
 

--- a/test/Admin.ts/Users.test.js
+++ b/test/Admin.ts/Users.test.js
@@ -1,12 +1,28 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-const { request, expect } = require('../testConfig')
+
+const { request, expect, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('Admin.ts/users endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
-  it('should get users', async () => {
+  it('should handle no authentication', async () => {
     response = await request.get('/user/admin/users/')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/admin/users/').set('Authorization', `Bearer ${testInvalidAccessToken}`)
+
+    expect(response.status).to.eql(401)
+  })
+
+  it('should get users', async () => {
+    response = await request.get('/user/admin/users/').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('all users RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -26,7 +42,9 @@ describe('Admin.ts/users endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user by id', async () => {
-    response = await request.get('/user/admin/users/$testUserId}')
+    response = await request.get('/user/admin/users/$testUserId}').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user by id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 

--- a/test/Api.ts/Labels.test.js
+++ b/test/Api.ts/Labels.test.js
@@ -1,43 +1,43 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
+
 const { request, expect, testLabelId } = require('../testConfig')
 
-describe('Api.ts/labels endpoint test', () => {
+describe.skip('Api.ts/labels endpoint test', () => {
   let response = null
 
   it('should get all labels', async () => {
     response = await request.get('/labels')
 
-    // relation \"rsntr_users\" does not exist"
-
+    console.log('should get all labels RESPONSE: ', response.text)
     expect(response.status).to.eql(200)
 
-    // const attributes = response.body
-    // expect(attributes).to.be.an('object')
-    // expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    const attributes = response.body
+    expect(attributes).to.be.an('object')
+    expect(attributes).to.include.keys('data', 'count', 'pages')
 
-    // expect(attributes.data).to.be.an('array')
-    // expect(attributes.data.length).to.eql(3)
+    expect(attributes.data).to.be.an('array')
+    expect(attributes.data.length).to.greaterThan(0)
 
-    // const theData = attributes.data[0]
-    // expect(theData).to.include.keys("")
-    // expect(theData.xxx).to.eql()
+    const theData = attributes.data[0]
+    expect(theData).to.include.keys('')
+    expect(theData.xxx).to.eql()
 
-    // expect(attributes.count).to.eql(1)
-    // expect(attributes.numberOfPages).to.eql(1)
-    // expect(attributes.status).to.eql('ok')
+    expect(attributes.count).to.eql(1)
+    expect(attributes.numberOfPages).to.eql(1)
+    expect(attributes.status).to.eql('ok')
   })
   it('should get a label by id', async () => {
     response = await request.get(`/labels/${testLabelId}`)
 
     expect(response.status).to.eql(200)
 
-    // const attributes = response.body
-    // expect(attributes).to.be.an('object')
-    // expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    const attributes = response.body
+    expect(attributes).to.be.an('object')
+    expect(attributes).to.include.keys('data', 'count', 'pages')
 
-    // expect(attributes.data).to.be.an('array')
-    // expect(attributes.data.length).to.eql(3)
+    expect(attributes.data).to.be.an('array')
+    expect(attributes.data.length).to.greaterThan(0)
 
     // const theData = attributes.data[0]
     // expect(theData).to.include.keys("")
@@ -52,12 +52,12 @@ describe('Api.ts/labels endpoint test', () => {
 
     expect(response.status).to.eql(200)
 
-    // const attributes = response.body
-    // expect(attributes).to.be.an('object')
-    // expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    const attributes = response.body
+    expect(attributes).to.be.an('object')
+    expect(attributes).to.include.keys('data', 'count', 'pages')
 
-    // expect(attributes.data).to.be.an('array')
-    // expect(attributes.data.length).to.eql(3)
+    expect(attributes.data).to.be.an('array')
+    expect(attributes.data.length).to.greaterThan(0)
 
     // const theData = attributes.data[0]
     // expect(theData).to.include.keys("")
@@ -72,12 +72,12 @@ describe('Api.ts/labels endpoint test', () => {
 
     expect(response.status).to.eql(200)
 
-    // const attributes = response.body
-    // expect(attributes).to.be.an('object')
-    // expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    const attributes = response.body
+    expect(attributes).to.be.an('object')
+    expect(attributes).to.include.keys('data', 'count', 'pages')
 
-    // expect(attributes.data).to.be.an('array')
-    // expect(attributes.data.length).to.eql(3)
+    expect(attributes.data).to.be.an('array')
+    expect(attributes.data.length).to.greaterThan(0)
 
     // const theData = attributes.data[0]
     // expect(theData).to.include.keys("")
@@ -92,12 +92,12 @@ describe('Api.ts/labels endpoint test', () => {
 
     expect(response.status).to.eql(200)
 
-    // const attributes = response.body
-    // expect(attributes).to.be.an('object')
-    // expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    const attributes = response.body
+    expect(attributes).to.be.an('object')
+    expect(attributes).to.include.keys('data', 'count', 'pages')
 
-    // expect(attributes.data).to.be.an('array')
-    // expect(attributes.data.length).to.eql(3)
+    expect(attributes.data).to.be.an('array')
+    expect(attributes.data.length).to.greaterThan(0)
 
     // const theData = attributes.data[0]
     // expect(theData).to.include.keys("")

--- a/test/Api.ts/Search.test.js
+++ b/test/Api.ts/Search.test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 const { request, expect } = require('../testConfig')
 
-describe('Api.ts/search endpoint test', () => {
+describe.skip('Api.ts/search endpoint test', () => {
   let response = null
 
   it('should handle no provided search term/s', async () => {

--- a/test/Api.ts/Tag.test.js
+++ b/test/Api.ts/Tag.test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 const { request, expect, testTagId } = require('../testConfig')
 
-describe('Api.ts/tag endpoint test', () => {
+describe.skip('Api.ts/tag endpoint test', () => {
   let response = null
 
   it('should get a tag by id', async () => {

--- a/test/Api.ts/Trackgroups.test.js
+++ b/test/Api.ts/Trackgroups.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
+
 const { request, expect, testTrackGroupId } = require('../testConfig')
 
 describe('Api.ts/Trackgroups endpoint test', () => {
@@ -19,22 +20,22 @@ describe('Api.ts/Trackgroups endpoint test', () => {
 
     const theData = attributes.data[0]
     expect(theData).to.include.keys('about', 'creatorId', 'display_artist', 'id', 'slug', 'tags', 'title', 'type', 'cover_metadata', 'userGroup', 'uri', 'images')
-    expect(theData.about).to.eql('this is the best album2')
-    expect(theData.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
-    expect(theData.display_artist).to.eql('Jill')
-    expect(theData.id).to.eql('5e2a28a8-d767-4b94-9a16-a6403848b512')
-    expect(theData.slug).to.eql('best-album-ever-2')
+    expect(theData.about).to.eql('this is the best album')
+    expect(theData.creatorId).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
+    expect(theData.display_artist).to.eql('Jack')
+    expect(theData.id).to.eql('84322e4f-0247-427f-8bed-e7617c3df5ad')
+    expect(theData.slug).to.eql('best-album-ever')
     expect(theData.tags).to.be.an('array')
     expect(theData.tags.length).to.eql(0)
-    expect(theData.title).to.eql('Best album ever 2')
+    expect(theData.title).to.eql('Best album ever')
     expect(theData.type).to.eql('lp')
     expect(theData.cover_metadata).to.be.null
 
     expect(theData.userGroup).to.include.keys('id', 'displayName')
-    expect(theData.userGroup.id).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
-    expect(theData.userGroup.displayName).to.eql('capacitor')
+    expect(theData.userGroup.id).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
+    expect(theData.userGroup.displayName).to.eql('matrix')
 
-    expect(theData.uri).to.eql('http://localhost:4000/v3/trackgroups/5e2a28a8-d767-4b94-9a16-a6403848b512')
+    expect(theData.uri).to.eql('http://localhost:4000/v3/trackgroups/84322e4f-0247-427f-8bed-e7617c3df5ad')
 
     expect(theData.images).to.include.keys('small', 'medium', 'large')
     expect(theData.images.small).to.include.keys('width', 'height')
@@ -47,7 +48,7 @@ describe('Api.ts/Trackgroups endpoint test', () => {
     expect(theData.images.large.width).to.eql(1500)
     expect(theData.images.large.height).to.eql(1500)
 
-    expect(attributes.count).to.eql(1)
+    expect(attributes.count).to.eql(3)
     expect(attributes.numberOfPages).to.eql(1)
     expect(attributes.status).to.eql('ok')
   })
@@ -65,43 +66,71 @@ describe('Api.ts/Trackgroups endpoint test', () => {
 
     const attributes = response.body
     expect(attributes).to.be.an('object')
-    expect(attributes).to.include.keys('data', 'count', 'numberOfPages', 'status')
+    expect(attributes).to.include.keys('data', 'status')
 
-    expect(attributes.data).to.be.an('array')
-    expect(attributes.data.length).to.eql(3) // there are three in the track_groups table
+    expect(attributes.data).to.be.an('object')
 
-    const theData = attributes.data[0]
-    expect(theData).to.include.keys('about', 'creatorId', 'display_artist', 'id', 'slug', 'tags', 'title', 'type', 'cover_metadata', 'userGroup', 'uri', 'images')
-    expect(theData.about).to.eql('this is the best album2')
-    expect(theData.creatorId).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
-    expect(theData.display_artist).to.eql('Jill')
-    expect(theData.id).to.eql('5e2a28a8-d767-4b94-9a16-a6403848b512')
-    expect(theData.slug).to.eql('best-album-ever-2')
-    expect(theData.tags).to.be.an('array')
-    expect(theData.tags.length).to.eql(0)
-    expect(theData.title).to.eql('Best album ever 2')
-    expect(theData.type).to.eql('lp')
-    expect(theData.cover_metadata).to.be.null
+    const theData = attributes.data
+    expect(theData).to.include.keys('about', 'cover_metadata', 'creatorId', 'display_artist', 'user', 'download', 'id', 'items', 'images', 'private', 'release_date', 'slug', 'tags', 'title', 'type')
+    expect(theData.about).to.eql('this is the best album')
 
-    expect(theData.userGroup).to.include.keys('id', 'displayName')
-    expect(theData.userGroup.id).to.eql('251c01f6-7293-45f6-b8cd-242bdd76cd0d')
-    expect(theData.userGroup.displayName).to.eql('capacitor')
+    expect(theData.cover_metadata).to.be.an('object')
+    expect(theData.cover_metadata).to.include.keys('id')
+    expect(theData.cover_metadata.id).to.be.null
 
-    expect(theData.uri).to.eql('http://localhost:4000/v3/trackgroups/5e2a28a8-d767-4b94-9a16-a6403848b512')
+    expect(theData.creatorId).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
+    expect(theData.display_artist).to.eql('Jack')
 
-    expect(theData.images).to.include.keys('small', 'medium', 'large')
+    expect(theData.user).to.be.an('object')
+    expect(theData.user).to.include.keys('name', 'id')
+    expect(theData.user.name).to.eql('matrix')
+    expect(theData.user.id).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
+
+    expect(theData.download).to.be.false
+    expect(theData.id).to.eql('84322e4f-0247-427f-8bed-e7617c3df5ad')
+
+    expect(theData.items).to.be.an('array')
+    expect(theData.items.length).to.eql(10)
+
+    const theItem = theData.items[0]
+    expect(theItem).to.be.an('object')
+    expect(theItem).to.include.keys('index', 'track')
+    expect(theItem.index).to.eql(0)
+
+    const theTrack = theItem.track
+    expect(theTrack).to.be.an('object')
+    expect(theTrack).to.include.keys('id', 'title', 'status', 'album', 'artistId', 'artist', 'images', 'url')
+    expect(theTrack.id).to.eql('44a28752-1101-4e0d-8c40-2c36dc82d035')
+    expect(theTrack.title).to.eql('Ergonomic interactive concept')
+    expect(theTrack.status).to.eql('free')
+    expect(theTrack.album).to.eql('firewall')
+    expect(theTrack.artistId).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
+    expect(theTrack.artist).to.eql('Laurie Yost')
+    expect(theTrack.images).to.be.an('object')
+    expect(theTrack.images).to.include.keys('small', 'medium')
+    expect(theTrack.images.small).to.include.keys('width', 'height')
+    expect(theTrack.images.small.width).to.eql(120)
+    expect(theTrack.images.small.height).to.eql(120)
+    expect(theTrack.images.medium).to.include.keys('width', 'height')
+    expect(theTrack.images.medium.width).to.eql(600)
+    expect(theTrack.images.medium.height).to.eql(600)
+
+    expect(theData.images).to.include.keys('small', 'medium')
     expect(theData.images.small).to.include.keys('width', 'height')
     expect(theData.images.small.width).to.eql(120)
     expect(theData.images.small.height).to.eql(120)
     expect(theData.images.medium).to.include.keys('width', 'height')
     expect(theData.images.medium.width).to.eql(600)
     expect(theData.images.medium.height).to.eql(600)
-    expect(theData.images.large).to.include.keys('width', 'height')
-    expect(theData.images.large.width).to.eql(1500)
-    expect(theData.images.large.height).to.eql(1500)
 
-    expect(attributes.count).to.eql(1)
-    expect(attributes.numberOfPages).to.eql(1)
+    expect(theData.private).to.be.false
+    expect(theData.release_date).to.eql('2019-01-01')
+    expect(theData.slug).to.eql('best-album-ever')
+    expect(theData.tags).to.be.an('array')
+    expect(theData.tags.length).to.eql(0)
+    expect(theData.title).to.eql('Best album ever')
+    expect(theData.type).to.eql('lp')
+
     expect(attributes.status).to.eql('ok')
   })
 })

--- a/test/Api.ts/Tracks.test.js
+++ b/test/Api.ts/Tracks.test.js
@@ -5,9 +5,9 @@ const { request, expect, testTrackId } = require('../testConfig')
 describe('Api.ts/track endpoint test', () => {
   let response = null
 
-  //  GET /tracks/${options.order !== "random" ? "latest" : ""}
-
   it('should get tracks when options.order is not \'random\'', async () => {
+    //  GET /tracks/${options.order !== "random" ? "latest" : ""}
+    //    if the endpoint call has options.order NOT 'random', add 'latest' to end of endpoint
     response = await request.get('/tracks/latest')
 
     expect(response.status).to.eql(200)
@@ -17,21 +17,21 @@ describe('Api.ts/track endpoint test', () => {
     expect(attributes).to.include.keys('data', 'count', 'numberOfPages')
 
     expect(attributes.data).to.be.an('array')
-    expect(attributes.data.length).to.eql(10)
+    expect(attributes.data.length).to.eql(30)
 
     //  FIXME: find a way to test all elements of data array. for now, just test the first one.
     const theData = attributes.data[0]
     expect(theData).to.include.keys('id', 'title', 'album', 'cover_metadata', 'artist', 'status', 'url', 'images')
-    expect(theData.id).to.eql('e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
-    expect(theData.title).to.eql('Universal 3rd generation hardware')
-    expect(theData.album).to.eql('hard drive')
+    expect(theData.id).to.eql('44a28752-1101-4e0d-8c40-2c36dc82d035')
+    expect(theData.title).to.eql('Ergonomic interactive concept')
+    expect(theData.album).to.eql('firewall')
 
     expect(theData.cover_metadata).to.include.keys('id')
     expect(theData.cover_metadata.id).to.be.null
 
     expect(theData.artist).to.be.null
     expect(theData.status).to.eql('Paid')
-    expect(theData.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
+    expect(theData.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/44a28752-1101-4e0d-8c40-2c36dc82d035')
 
     expect(theData.images).to.include.keys('small', 'medium')
     expect(theData.images.small).to.include.keys('width', 'height')
@@ -41,29 +41,53 @@ describe('Api.ts/track endpoint test', () => {
     expect(theData.images.medium.width).to.eql(600)
     expect(theData.images.medium.height).to.eql(600)
 
-    expect(attributes.count).to.eql(10)
+    expect(attributes.count).to.eql(30)
     expect(attributes.numberOfPages).to.eql(1)
   })
 
   it('should get tracks when options.order is \'random\'', async () => {
+    //  GET /tracks/${options.order !== "random" ? "latest" : ""}
+    //    if the endpoint call has options.order is 'random', add nothing to end of endpoint
     response = await request.get('/tracks')
 
     expect(response.status).to.eql(200)
 
-    // const attributes = response.body
-    // expect(attributes).to.be.an('object')
-    // expect(attributes).to.include.keys("data", "count", "numberOfPages", "status")
+    const attributes = response.body
+    expect(attributes).to.be.an('object')
+    expect(attributes).to.include.keys('data', 'count', 'numberOfPages', 'status')
 
-    // expect(attributes.data).to.be.an('array')
-    // expect(attributes.data.length).to.eql(3)
+    expect(attributes.data).to.be.an('array')
+    expect(attributes.data.length).to.eql(31)
 
-    // const theData = attributes.data[0]
-    // expect(theData).to.include.keys("")
-    // expect(theData.xxx).to.eql()
+    const theData = attributes.data[0]
+    expect(theData).to.be.an('object')
+    expect(theData).to.include.keys('id', 'title', 'album', 'year', 'cover_metadata', 'artist', 'status', 'url', 'images')
 
-    // expect(attributes.count).to.eql(1)
-    // expect(attributes.numberOfPages).to.eql(1)
-    // expect(attributes.status).to.eql('ok')
+    expect(theData.id).to.eql('fcf41302-e549-4ab9-9937-f0bfead5a44f')
+    expect(theData.title).to.eql('Virtual clear-thinking standardization')
+    expect(theData.album).to.eql('driver')
+    expect(theData.year).to.be.null
+
+    expect(theData.cover_metadata).to.be.an('object')
+    expect(theData.cover_metadata).to.include.keys('id')
+    expect(theData.cover_metadata.id).to.be.null
+
+    expect(theData.artist).to.be.null
+    expect(theData.status).to.eql('Paid')
+    expect(theData.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/fcf41302-e549-4ab9-9937-f0bfead5a44f')
+
+    expect(theData.images).to.be.an('object')
+    expect(theData.images).to.include.keys('small', 'medium')
+    expect(theData.images.small).to.include.keys('width', 'height')
+    expect(theData.images.small.width).to.eql(120)
+    expect(theData.images.small.height).to.eql(120)
+    expect(theData.images.medium).to.include.keys('width', 'height')
+    expect(theData.images.medium.width).to.eql(600)
+    expect(theData.images.medium.height).to.eql(600)
+
+    expect(attributes.count).to.eql(31)
+    expect(attributes.numberOfPages).to.eql(1)
+    expect(attributes.status).to.eql('ok')
   })
   it('should get track by id', async () => {
     response = await request.get(`/tracks/${testTrackId}`)
@@ -78,16 +102,17 @@ describe('Api.ts/track endpoint test', () => {
 
     const theData = attributes.data
     expect(theData).to.include.keys('id', 'creatorId', 'title', 'album', 'year', 'artist', 'cover_metadata', 'status', 'url', 'images')
-    expect(theData.id).to.eql('e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
-    expect(theData.title).to.eql('Universal 3rd generation hardware')
+    expect(theData.id).to.eql('b6d160d1-be16-48a4-8c4f-0c0574c4c6aa')
+    expect(theData.creatorId).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
+    expect(theData.title).to.eql('Sharable maximized utilisation')
     expect(theData.album).to.eql('hard drive')
+    expect(theData.year).to.be.null
+    expect(theData.artist).to.eq; ('matrix')
 
-    expect(theData.cover_metadata).to.include.keys('id')
-    expect(theData.cover_metadata.id).to.be.null
+    expect(theData.cover_metadata).to.be.an('object')
 
-    expect(theData.artist).to.eq; ('capacitor')
     expect(theData.status).to.eql('Paid')
-    expect(theData.url).to.eql('https://api.resonate.is/v1/stream/e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def')
+    expect(theData.url).to.eql('https://api.resonate.is/v1/stream/b6d160d1-be16-48a4-8c4f-0c0574c4c6aa')
 
     expect(theData.images).to.include.keys('small', 'medium', 'large')
     expect(theData.images.small).to.include.keys('width', 'height')

--- a/test/MockAccessToken.js
+++ b/test/MockAccessToken.js
@@ -4,7 +4,7 @@
 //    hopefully you get the idea behind it.
 // 'require' this in tests that need to pass accessToken-based authentication.
 //    In the test's primary 'describe' block, enter
-//      require('../BeforeAndAfter.js')
+//      require('../MockAccessToken.js')
 //      as the first line inside of the describe block
 //    Look at test/auth/AccessTokenExample.test.js for more infos
 
@@ -19,10 +19,7 @@ before('send access token to Redis', () => {
     accountId: testUserId
   })
 })
-// Remove a test access token from a Redis. Because we are thoughtful and clean up
-//    after ourselves.
+// Remove a test access token from a Redis.
 after('remove access token from Redis', () => {
   adapter.destroy(testAccessToken)
-  //  FIXME: should also remove / disconnect / destroy adapter
-  //      does this simply happen by itself when the test exits?
 })

--- a/test/README.md
+++ b/test/README.md
@@ -9,16 +9,21 @@ These tests reference the [beam](https://github.com/resonatecoop/beam/tree/main/
 
 The api(v4) tests live in the `/api/test` directory. In this directory there are three subfolders (`Admin.ts`, `Api.ts`, and `User.ts`), each of which corresponds to a file in the [beam](https://github.com/resonatecoop/beam/tree/main/src/services) repository.
 
-## How the test data was made
-You can read an overview of how the test data was made [here](./HowTheTestDataWasMade.md). 
+## Dev Notes
+This section changes over time, as issues arise and are dealt with.
+* It looks like the protected endpoints will accept any value for an accessToken, and that the only check against this token is whether or not it is provided.
+* Many of the endpoints return a 404 code, when perhaps a 400 is more appropriate.
+* We are skipping tests for `Labels`, `Tags`, and `Search` because of upstream data migration issues and incomplete funcitonality to be resolved at some point soon.
 
+## How the test data was made
+You should never need to create test data. However, you can read an overview of how the test data was made [here](./HowTheTestDataWasMade.md). 
 
 ## Setup and running
 First, start up the Docker test container.
 ```sh
 yarn docker:compose:test:up
 ```
-If this is the first time you have started this test container, you will need to seed the test database. You don't have to do this every time you start the test container.
+If this is the first time you have started this test container, you will need to seed the test database. You should only do this once. You don't have to do this every time you start the test container.
 ```sh
 docker:seed:all:test
 ```
@@ -29,7 +34,9 @@ To stop the Docker test container.
 yarn docker:compose:test:down
 ```
 
-Once the test Docker container is seeded and up, you can run tests.
+Once the test Docker container is seeded and up, you can run tests. Please note that the tests are designed to run in `watch` mode. You can change this in the `.mocharc.js` file, but please be careful so that you don't break anything.
+
+Open a new terminal window. It is often helpful to open it next to the terminal window which displays the output of the Docker test container. 
 
 Run the tests for endpoints in Api.ts file
 ```sh
@@ -46,35 +53,34 @@ Run the tests for endpoints in User.ts file
 yarn test:user
 ```
 
-You can run a test in `watch` mode, from the command line. This is helpful while you work on a test, or work on the functionality being tested.
-```sh
-mocha -w someFilePath/someTestFileName
-```
+These tests run under Mocha in watch mode. If you are not familiar with Mocha, take a moment and familiarize yourself with `only` and `skip`. `only` and `skip` are your friends, and can help focus on specific tests as they are being developed, or problems with tests, or when a test fails, etc.
 
 You can create more test script commands in the api (v4) repo's `package.json` file, if you need something else.
 
-## Notes
+## Configuration and how to make more tests
+There is a file named `.mocharc.js` located in the project root. This file contains configuration settings. If you change it, you might break things.
+
 There is a file named `Template.test.js` in the `test` folder. You can copy this file to start writing new tests more quickly.
 
 There is a file named `testConfig.js` in the `test` folder. It has vars and modules that are used in test files. It's basically used as an include header at the beginning of each test file. If you create new tests, this file will help you go faster.
 
 In `testConfig.js` there is a const `baseURL`. This is set to `http://localhost:4000/api/v3` so that you can run the tests against a local Dockerized resonate api (v4) container instance. If you need to run the tests against a different instance of the API, you can comment this const out and replace it with a url of your choosing, ie `const baseURL = 'http://awesome.sauce.com/api/v2'` or similar.
 
-These tests run under Mocha as test runner. If you are not familiar with Mocha, take a moment and familiarize yourself with `only` and `skip`. `only` and `skip` are your friends, and can help on specific tests as they are being developed, or problems with tests, or when a test fails, etc.
-
-This testing suite uses Mocha, and Mocha will be installed as a dev dependency if / when you run `yarn` at the repo root.
-
-This testing suite uses some assertions from Chai, and Chai will be installed as a dev dependency if / when you run `yarn` at the repo root.
+There is a file named `MockAccessToken.js` in the `test` folder. This file can help you test endpoints that require authentication. It's rather simple. Refer to the file for more infos.
 
 ## The Tests
 These are tests for api (v4). They are currently based on endpoints revealed [in this document](https://github.com/resonatecoop/beam/tree/main/src/services).
 
 Still not clear on how well the endpoints map to the underlying data.
 
-For this iteration of these tests, we capture the endpoints' output and return that output to the tests. This is a 'what does it do?' and not a 'what should it do?' approach. Later iterations of test development should focus on testing actual required functionality and valid test data.
+For this iteration of these tests, we capture the endpoints' output and return that output to the tests. This tests answer the questions 'what do we have?' and 'what does it do?' and not 'what should it do?'. Later iterations of test development should focus on testing actual required functionality and valid test data.
 
 ### Api.ts tests
 
+* Currently we are skipping `Labels` tests and `Tags` tests. This is due to issues upstream with legacy data migration.
+* Currently we are skipping `Search ` tests. This can continue once search functionality is implemented. This implementation should occur after initial test development is complete.
+
+  
 Run the tests for endpoints in Api.ts file
 ```sh
 yarn test:api
@@ -112,8 +118,6 @@ Run the tests for endpoints in Admin.ts file
 yarn test:admin
 ```
 
-These tests are incomplete. Main thing to do next is implement a way to get access token from test target.
-
 Endpoints in [Admin.ts](https://github.com/resonatecoop/beam/blob/main/src/services/api/Admin.ts)
 
 * users
@@ -133,8 +137,6 @@ Run the tests for endpoints in User.ts file
 ```sh
 yarn test:user
 ```
-
-These tests are incomplete. Main thing to do next is implement a way to get access token from test target.
 
 Endpoints in [User.ts](https://github.com/resonatecoop/beam/blob/main/src/services/api/User.ts)
 
@@ -172,17 +174,11 @@ Endpoints in [User.ts](https://github.com/resonatecoop/beam/blob/main/src/servic
 * products
   * GET /user/products
 
-As work on the new API continues, you might need to edit the existing tests, as well as create new tests. You can use `Template.test.js` and `testConfig.js`, located in the `test` folder, to get started with new tests.
+As work on the new API continues, you might need to edit the existing tests, as well as create new tests. You can use `Template.test.js`, `testConfig.js` and `MockAccessToken`, located in the `test` folder, to get started with new tests.
 
 ## To Do
-* Find a simple, straightforward way to get access tokens.
-  * These are needed in the Admin.ts and User.ts tests.
-  * Most straightforward solution would be to copy the login process and capture the token in the response.
-* Look over api/src/db/models/* to get a better idea of what the data/datatypes are.
-* It might be good to run tests from within Docker, using `docker exec -it resonate-api mocha <some.test.js>`? 
-  * Not sure if this helps anything.
-* Configure Mocha 
-  * error log naming / location
-  * anything else useful
-    * --reporter type?
+* Finish `Labels` and `Tags` testing once upstream data issues are resolved.
+* Implement search endpoint.
+* Resume test development for endpoints that currently have no data (Labels, Tags, etc.).
+* Look over api/src/db/models/ files to get a better idea of what the data/datatypes are.
 * Better / more TypeScript integration

--- a/test/User.ts/MiscUserInfo.test.js
+++ b/test/User.ts/MiscUserInfo.test.js
@@ -1,15 +1,31 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-const { request, expect } = require('../testConfig')
+
+const { request, expect, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('User.ts/misc user info endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
   const from = '2020-01-01'
   const to = '2020-12-31'
 
+  it('should handle no authentication / accessToken', async () => {
+    response = await request.get('/user/plays/')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/plays/').set('Authorization', `Bearer ${testInvalidAccessToken}`)
+
+    expect(response.status).to.eql(401)
+  })
+
   it('should get user plays within date range', async () => {
-    response = await request.get(`/user/plays/stats?from=${from}&to=${to}`)
+    response = await request.get(`/user/plays/stats?from=${from}&to=${to}`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user plays within date range RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -29,7 +45,9 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user plays history artists (?)', async () => {
-    response = await request.get('/user/plays/history/artists')
+    response = await request.get('/user/plays/history/artists').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user plays history artists RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -49,7 +67,9 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user collections', async () => {
-    response = await request.get('/user/collection/')
+    response = await request.get('/user/collection/').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user collections RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -69,7 +89,9 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user plays history', async () => {
-    response = await request.get('/user/plays/history/')
+    response = await request.get('/user/plays/history/').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user plays history RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -89,7 +111,9 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user favorites', async () => {
-    response = await request.get('/user/favorites')
+    response = await request.get('/user/favorites').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user favorites RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -109,7 +133,9 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user favorites (no user id? all of them?)', async () => {
-    response = await request.post('/user/favorites')
+    response = await request.post('/user/favorites').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to user favorites RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -129,7 +155,9 @@ describe('User.ts/misc user info endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user favorites resolve (?)', async () => {
-    response = await request.get('/user/favorites/resolve')
+    response = await request.get('/user/favorites/resolve').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to user favorites resolve RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/Products.test.js
+++ b/test/User.ts/Products.test.js
@@ -1,12 +1,28 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-const { request, expect } = require('../testConfig')
+
+const { request, expect, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('User.ts/products endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
-  it('should get user products', async () => {
+  it('should handle no authentication / accessToken', async () => {
     response = await request.get('/user/products')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/products').set('Authorization', `Bearer ${testInvalidAccessToken}`)
+
+    expect(response.status).to.eql(401)
+  })
+
+  it('should get user products', async () => {
+    response = await request.get('/user/products').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user products RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/User.test.js
+++ b/test/User.ts/User.test.js
@@ -1,14 +1,28 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-// Needs auth token
 
-const { request, expect, testUserId, testTrackGroupId } = require('../testConfig')
+const { request, expect, testUserId, testTrackGroupId, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('User.ts/user endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
+  it('should handle no authentication / accessToken', async () => {
+    response = await request.get('/user/profile')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/profile').set('Authorization', `Bearer ${testInvalidAccessToken}`)
+
+    expect(response.status).to.eql(401)
+  })
+
   it('should get user profiles', async () => {
-    response = await request.get('/user/profile/')
+    response = await request.get('/user/profile/').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user profiles RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -28,7 +42,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user playlists by user id', async () => {
-    response = await request.get(`/users/${testUserId}/playlists`)
+    response = await request.get(`/users/${testUserId}/playlists`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('playlists by user id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -48,7 +64,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user/trackgroups', async () => {
-    response = await request.post('/user/trackgroups')
+    response = await request.post('/user/trackgroups').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to user trackgroups RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -68,7 +86,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should should update user trackgroups by trackgroup id', async () => {
-    response = await request.put(`/user/trackgroups/${testTrackGroupId}`)
+    response = await request.put(`/user/trackgroups/${testTrackGroupId}`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('put to user trackgroup by id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -88,7 +108,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user trackgroups', async () => {
-    response = await request.get('/user/trackgroups')
+    response = await request.get('/user/trackgroups').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('get user trackgroups RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -108,7 +130,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should get user trackgroups by trackgroup id', async () => {
-    response = await request.get(`/user/trackgroups/${testTrackGroupId}`)
+    response = await request.get(`/user/trackgroups/${testTrackGroupId}`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user trackgroup by trackgroup id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -128,7 +152,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to a trackgroup by trackgroup id', async () => {
-    response = await request.get(`/user/trackgroups/${testTrackGroupId}/items/add`)
+    response = await request.get(`/user/trackgroups/${testTrackGroupId}/items/add`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to a trackgroup by trackgroup id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -148,7 +174,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should remove an item from a trackgroup by trackgroup id', async () => {
-    response = await request.put(`/user/trackgroups/${testTrackGroupId}/items/remove`)
+    response = await request.put(`/user/trackgroups/${testTrackGroupId}/items/remove`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('remove an item from a trackgroup by trackgroup id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -168,7 +196,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should update trackgroup items by trackgroup id', async () => {
-    response = await request.put(`/user/trackgroups/${testTrackGroupId}/items`)
+    response = await request.put(`/user/trackgroups/${testTrackGroupId}/items`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('update trackgroup items by trackgroup id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -188,7 +218,9 @@ describe('User.ts/user endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should delete from trackgroups by trackgroup id', async () => {
-    response = await request.delete(`/user/trackgroups/${testTrackGroupId}`)
+    response = await request.delete(`/user/trackgroups/${testTrackGroupId}`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('delete from trackgroups by trackgroup id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/UserArtist.test.js
+++ b/test/User.ts/UserArtist.test.js
@@ -1,14 +1,28 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-//  needs auth token
 
-const { request, expect, testArtistId } = require('../testConfig')
+const { request, expect, testArtistId, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('User.ts/user artist endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
-  it('should get user artists', async () => {
+  it('should handle no authentication / accessToken', async () => {
     response = await request.get('/user/artists')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/artists').set('Authorization', `Bearer ${testInvalidAccessToken}`)
+
+    expect(response.status).to.eql(401)
+  })
+
+  it('should get user artists', async () => {
+    response = await request.get('/user/artists').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('all user artists RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -28,7 +42,9 @@ describe('User.ts/user artist endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should user artists by artist id', async () => {
-    response = await request.get(`/user/artists/${testArtistId}`)
+    response = await request.get(`/user/artists/${testArtistId}`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('user artists by artist id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -48,7 +64,9 @@ describe('User.ts/user artist endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user artists', async () => {
-    response = await request.post('/user/artists')
+    response = await request.post('/user/artists').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to user artists RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/UserPlays.test.js
+++ b/test/User.ts/UserPlays.test.js
@@ -1,12 +1,28 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-const { request, expect } = require('../testConfig')
+
+const { request, expect, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('User.ts/user plays endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
-  it('should post to user plays (all of them?)', async () => {
+  it('should handle no authentication / accessToken', async () => {
     response = await request.get('/user/plays')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/plays').set('Authorization', `Bearer ${testInvalidAccessToken}`)
+
+    expect(response.status).to.eql(401)
+  })
+
+  it('should post to user plays (all of them?)', async () => {
+    response = await request.get('/user/plays').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to user plays RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -26,7 +42,9 @@ describe('User.ts/user plays endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user plays buy', async () => {
-    response = await request.post('/user/plays/buy')
+    response = await request.post('/user/plays/buy').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to user plays buy RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -46,7 +64,9 @@ describe('User.ts/user plays endpoint test', () => {
     // expect(attributes.status).to.eql('ok')
   })
   it('should post to user plays resolve (?)', async () => {
-    response = await request.get('/user/plays/resolve')
+    response = await request.get('/user/plays/resolve').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to user plays resolve RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 

--- a/test/User.ts/UserTracks.test.js
+++ b/test/User.ts/UserTracks.test.js
@@ -1,12 +1,27 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
-const { request, expect, testTrackId, testTrackGroupId } = require('../testConfig')
+const { request, expect, testTrackId, testTrackGroupId, testAccessToken, testInvalidAccessToken } = require('../testConfig')
 
 describe('User.ts/user tracks endpoint test', () => {
+  require('../MockAccessToken')
+
   let response = null
 
+  it('should handle no authentication / accessToken', async () => {
+    response = await request.get('/user/tracks')
+
+    expect(response.status).to.eql(401)
+  })
+  it('should handle an invalid access token', async () => {
+    response = await request.get('/user/tracks').set('Authorization', `Bearer ${testInvalidAccessToken}`)
+
+    expect(response.status).to.eql(401)
+  })
+
   it('should post to user tracks', async () => {
-    response = await request.post('/user/tracks')
+    response = await request.post('/user/tracks').set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('post to all user tracks RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 
@@ -27,7 +42,9 @@ describe('User.ts/user tracks endpoint test', () => {
   })
   it('should upload a file based on track id', async () => {
     // FIXME: is put the right verb? should be post?
-    response = await request.put(`/user/tracks/${testTrackId}/file `)
+    response = await request.put(`/user/tracks/${testTrackId}/file `).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('upload a file based on track id RESPONSE: ', response.text)
 
     expect(response.status).to.eql()
 
@@ -48,7 +65,9 @@ describe('User.ts/user tracks endpoint test', () => {
   })
   it('should upload a cover (image?) based on trackgroup id', async () => {
     // FIXME: is put the right verb? should be post?
-    response = await request.put(`/user/trackgroups/${testTrackGroupId}/cover`)
+    response = await request.put(`/user/trackgroups/${testTrackGroupId}/cover`).set('Authorization', `Bearer ${testAccessToken}`)
+
+    console.log('upload a cover based on trackgroup id RESPONSE: ', response.text)
 
     expect(response.status).to.eql(200)
 

--- a/test/auth/AccessTokenExample.test.js
+++ b/test/auth/AccessTokenExample.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
 
-// How to use the MockAccessToken.js file≥
+// How to use the MockAccessToken.js file
 const { testAccessToken, testUserId } = require('../testConfig')
 
 describe('Access token example test', () => {

--- a/test/testConfig.js
+++ b/test/testConfig.js
@@ -9,16 +9,18 @@ const persistedRequest = require('supertest').agent(baseURL)
 
 const expect = require('chai').expect
 
+//  FIXME: have to switch REDIS_HOST to 127.0.0.1 and comment out REDIS_PASSWORD to get tests to run.
 const TestRedisAdapter = require('../src/auth/redis-adapter')
 
 const testUserId = '17203153-e2b0-457f-929d-5abe4e322ea1'
-const testTrackGroupId = 'c91bf101-2d3d-4181-8010-627ecce476de'
+const testTrackGroupId = '84322e4f-0247-427f-8bed-e7617c3df5ad'
 const testTagId = 'asdf'
 const testLabelId = 'asdf'
 const testArtistId = '49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6'
-const testTrackId = 'e8fc6dd4-f6ed-4b2b-be0f-efe9f32c3def'
+const testTrackId = 'b6d160d1-be16-48a4-8c4f-0c0574c4c6aa'
 
 const testAccessToken = 'test-!@#$-test-%^&*'
+const testInvalidAccessToken = 'invalid-invalid-invalid-invalid'
 
 module.exports = {
   baseURL,
@@ -32,5 +34,6 @@ module.exports = {
   testArtistId,
   testTrackId,
   testAccessToken,
-  TestRedisAdapter
+  TestRedisAdapter,
+  testInvalidAccessToken
 }


### PR DESCRIPTION
- Added 'mock access token' functionality and applied to Admin.ts and User.ts tests.
- Got tests to run inside of Docker test container.
- Tests run as yarn scripts, in watch mode.
- Finished all relevant tests for Api.ts folder.
- Relevant Api.ts tests pass.

This is a big step forward, however there is much more distance to travel.

Next step/s: Finish tests for Admin.ts and User.ts endpoints.