### PR TITLE
feat: add email sending to user registration. close #17

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,4 +29,6 @@ REDIS_PASSWORD=password
 
 STRIPE_KEY=test
 
-CI=false
+MAILGUN_API_KEY=test
+MAILGUN_DOMAIN=test
+MAILGUN_SENDER=no-reply@resonate.coop

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -3,6 +3,8 @@
 // https://www.testim.io/blog/mocharc-configuration/
 // https://stackoverflow.com/questions/72479267/mocha-watch-with-docker
 
+// CI is set to true set by the CI provider (GitHub Actions in our case)
+// We don't need to worry about it locally.
 const shouldWatch = process.env.CI === "true" ? false : true;
 
 module.exports = {

--- a/emails/earnings-report/html.pug
+++ b/emails/earnings-report/html.pug
@@ -1,0 +1,24 @@
+doctype html
+html
+  head
+    block head
+      meta(charset="utf-8")
+      meta(name="viewport", content="width=device-width")
+      meta(http-equiv="X-UA-Compatible", content="IE=edge")
+      meta(name="x-apple-disable-message-reformatting")
+      link(rel="stylesheet", href="style.css", data-inline)
+  body.sans-serif
+    p Hi #{firstName},
+
+    p
+     | Here's your earnings report for the period from 
+     b #{from}
+     |  to 
+     b #{to}
+
+    p 
+     | Reply to 
+     a(href='mailto:members@resonate.is') members@resonate.is
+     |  if you have any questions.
+
+    p The Resonate team

--- a/emails/earnings-report/subject.pug
+++ b/emails/earnings-report/subject.pug
@@ -1,0 +1,1 @@
+= `Resonate earnings Report`

--- a/emails/earnings-report/text.pug
+++ b/emails/earnings-report/text.pug
@@ -1,0 +1,7 @@
+| Hi #{firstName},
+|
+| Here's your earnings report for the period from #{from} to #{to}
+|
+| Reply to members@resonate.is if you have any questions.
+|
+| The Resonate team

--- a/emails/new-upload/html.pug
+++ b/emails/new-upload/html.pug
@@ -1,0 +1,24 @@
+doctype html
+html
+  head
+    block head
+      meta(charset="utf-8")
+      meta(name="viewport", content="width=device-width")
+      meta(http-equiv="X-UA-Compatible", content="IE=edge")
+      meta(name="x-apple-disable-message-reformatting")
+      link(rel="stylesheet", href="style.css", data-inline)
+  body.sans-serif
+    .pa4
+      .overflow-auto
+        table.f6.w-100.mw8.center(cellspacing='0')
+          thead
+            tr.stripe-dark
+              th.fw6.tl.pa3.bg-white Id
+              th.fw6.tl.pa3.bg-white Filesize
+              th.fw6.tl.pa3.bg-white Email
+          tbody.lh-copy
+            tr.stripe-dark
+              td.pa3 #{id}
+              td.pa3 #{filesize}
+              td.pa3 #{email}
+            tr.stripe-dark

--- a/emails/new-upload/subject.pug
+++ b/emails/new-upload/subject.pug
@@ -1,0 +1,1 @@
+= `New upload ready`

--- a/emails/new-upload/text.pug
+++ b/emails/new-upload/text.pug
@@ -1,0 +1,2 @@
+| Hi #{name},
+| This is just a text test.

--- a/emails/new-user/html.pug
+++ b/emails/new-user/html.pug
@@ -1,0 +1,17 @@
+doctype html
+html
+  head
+    block head
+      meta(charset="utf-8")
+      meta(name="viewport", content="width=device-width")
+      meta(http-equiv="X-UA-Compatible", content="IE=edge")
+      meta(name="x-apple-disable-message-reformatting")
+      style 
+        include ../style.css
+  body.sans-serif
+    p Hi!
+    p Someone signed up to resonate using this email address
+    p #{user.email}
+    p 
+      a(href=`${host}/register/emailConfirmation/${user.emailConfirmationToken}?email=${user.email}`) Click here to confirm
+    p If this was not you, you can safely ignore this email.

--- a/emails/new-user/subject.pug
+++ b/emails/new-user/subject.pug
@@ -1,0 +1,1 @@
+= `Welcome to resonate!`

--- a/emails/new-user/text.pug
+++ b/emails/new-user/text.pug
@@ -1,0 +1,8 @@
+| Hi!
+| Someone signed up to resonate using this email address
+|
+| #{user.email}
+|
+| Click this link to confirm: #{host}/register/emailConfirmation/#{user.emailConfirmationToken}?email=#{user.email}
+| 
+| If this was not you, you can ignore this email.

--- a/emails/style.css
+++ b/emails/style.css
@@ -1,0 +1,62 @@
+.sans-serif {
+  font-family: -apple-system, BlinkMacSystemFont,
+  'avenir next', avenir,
+  'helvetica neue', helvetica,
+  ubuntu,
+  roboto, noto,
+  'segoe ui', arial,
+  sans-serif;
+}
+
+.b {
+  font-weight: bold;
+}
+
+.fw6 {
+  font-weight: 600;
+}
+
+.lh-copy {
+  line-height: 1.5;
+}
+
+.mw8 {
+  max-width: 64rem;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.overflow-auto {
+  overflow: auto;
+}
+
+.bg-white {
+  background-color: #fff;
+}
+
+.pa3 {
+  padding: 1rem;
+}
+
+.pa4 {
+  padding: 2rem;
+}
+
+.stripe-dark:nth-child(odd) {
+  background-color: rgba(0, 0, 0, .1);
+}
+
+.tl {
+  text-align: left;
+}
+
+.f6 {
+  font-size: .875rem;
+}
+
+.center {
+  margin-right: auto;
+  margin-left: auto;
+}

--- a/emails/test/html.pug
+++ b/emails/test/html.pug
@@ -1,0 +1,12 @@
+doctype html
+html
+  head
+    block head
+      meta(charset="utf-8")
+      meta(name="viewport", content="width=device-width")
+      meta(http-equiv="X-UA-Compatible", content="IE=edge")
+      meta(name="x-apple-disable-message-reformatting")
+      link(rel="stylesheet", href="style.css", data-inline)
+  body.sans-serif
+    p Hi #{firstName},
+    p How are you doing?

--- a/emails/test/subject.pug
+++ b/emails/test/subject.pug
@@ -1,0 +1,1 @@
+= `This is a test`

--- a/emails/test/text.pug
+++ b/emails/test/text.pug
@@ -1,0 +1,2 @@
+| Hi #{name},
+| This is just a text test.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "koa-cash": "^4.0.5",
     "koa-compress": "^3.1.0",
     "koa-etag": "^4.0.0",
+    "koa-flash": "^1.0.0",
     "koa-json-error": "^3.1.2",
     "koa-logger": "^3.2.1",
     "koa-mount": "^4.0.0",

--- a/src/auth/public/style.css
+++ b/src/auth/public/style.css
@@ -60,6 +60,23 @@ form button {
   list-style: none;
 }
 
+.error ul,
+.success ul {
+  padding: 1.5rem 2rem;
+  list-style: none;
+  max-width: 600px;
+}
+
+.error ul {
+  background: #ffe9e9;
+  color: red;
+}
+
+.success ul {
+  background: lightblue;
+  color: navy;
+}
+
 #footer {
   text-align: center;
   font-size: .75rem;

--- a/src/auth/views/email-confirmed.pug
+++ b/src/auth/views/email-confirmed.pug
@@ -1,0 +1,4 @@
+extends layout.pug 
+
+block content 
+  h2 Registration step: confirming email

--- a/src/auth/views/interaction-login.pug
+++ b/src/auth/views/interaction-login.pug
@@ -2,7 +2,7 @@ extends layout.pug
 
 block content 
   h1 Log in
-  form(action=`/login`, method="post", autocomplete="off")
+  form(action=`/interaction/${uid}/login`, method="post", autocomplete="off")
     input(type="email", name="email", placeholder="Enter your email")
     input(type="password", name="password", placeholder="and password") 
     button(type="submit") 

--- a/src/auth/views/layout.pug
+++ b/src/auth/views/layout.pug
@@ -8,8 +8,14 @@ html
     block scripts
       //- script(src='/jquery.js')
   body
+    if messages
+    for val, key in messages
+        div(class=key)
+          ul
+            each val in messages[key]
+              li #{val}
     div.content
       block content
     block foot
       #footer
-        p Logging in to Resonate Services
+        p Authentication provided by #[a(href="https://resonate.coop") Resonate].

--- a/src/config/session.js
+++ b/src/config/session.js
@@ -8,6 +8,6 @@ module.exports = {
   signed: true,
   rolling: false,
   renew: false,
-  secure: true,
+  secure: process.env.NODE_ENV === 'production',
   sameSite: 'None'
 }

--- a/src/db/migrations/202207140053-user.js
+++ b/src/db/migrations/202207140053-user.js
@@ -59,6 +59,12 @@ module.exports = {
         type: DataTypes.DATE,
         field: 'last_password_change'
       },
+      emailConfirmationToken: {
+        defaultValue: DataTypes.UUIDV4,
+        type: DataTypes.UUID,
+        unique: true,
+        field: 'email_confirmation_token'
+      },
       roleId: {
         type: DataTypes.INTEGER,
         allowNull: false,

--- a/src/db/models/resonate/user.js
+++ b/src/db/models/resonate/user.js
@@ -63,8 +63,14 @@ module.exports = (sequelize, DataTypes) => {
     lastPasswordChange: {
       type: DataTypes.DATE
     },
+    emailConfirmationToken: {
+      defaultValue: DataTypes.UUIDV4,
+      type: DataTypes.UUID,
+      unique: true
+    },
     roleId: {
-      type: DataTypes.INTEGER
+      type: DataTypes.INTEGER,
+      allowNull: false
     },
     updatedAt: {
       allowNull: false,

--- a/src/db/seeders/trackgroup-seeder.js
+++ b/src/db/seeders/trackgroup-seeder.js
@@ -8,7 +8,7 @@ const generateTracks = async (trackgroup, listener) => {
       const track = await Track.create({
         creatorId: trackgroup.creatorId,
         title: faker.company.catchPhrase(),
-        artist: faker.name.findName(),
+        artist: faker.name.fullName(),
         album: faker.hacker.noun(),
         status: 'free',
         date: faker.date.past(1)
@@ -139,7 +139,7 @@ module.exports = {
         id: testTrackId,
         creatorId: albums[0].creatorId,
         title: faker.company.catchPhrase(),
-        artist: faker.name.findName(),
+        artist: faker.name.fullName(),
         album: faker.hacker.noun(),
         status: 'free',
         date: faker.date.past(1)

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const { koaSwagger } = require('koa2-swagger-ui')
 const cors = require('@koa/cors')
 const ratelimit = require('koa-ratelimit')
 const Redis = require('ioredis')
+const flash = require('koa-flash')
 
 const KeyGrip = require('keygrip')
 
@@ -75,6 +76,7 @@ app
     }
   }))
   .use(session(sessionConfig, app))
+  .use(flash())
   .use(compress(compressConfig()))
   .use(koaSwagger(swaggerConfig())) // swagger-ui at /docs
   .use(koaCash(koaCashConfig()))

--- a/src/jobs/send-mail.js
+++ b/src/jobs/send-mail.js
@@ -40,19 +40,26 @@ const sendMail = async (job) => {
           relativeTo: path.resolve(viewsDir)
         }
       },
-      transport: nodemailer.createTransport(mailgun({
-        auth: {
-          api_key: process.env.MAILGUN_API_KEY,
-          domain: process.env.MAILGUN_DOMAIN
-        }
-      }))
+      transport: nodemailer.createTransport(
+        mailgun({
+          auth: {
+            api_key: process.env.MAILGUN_API_KEY,
+            domain: process.env.MAILGUN_DOMAIN
+          }
+        })
+      )
     })
 
-    await email.send({
-      template: job.data.template,
-      message: job.data.message,
-      locals: job.data.locals
-    })
+    if (process.env.NODE_ENV === 'production') {
+      await email.send({
+        template: job.data.template,
+        message: job.data.message,
+        locals: job.data.locals
+      })
+    } else {
+      email.render(job.data.template + '/html', job.data.locals)
+        .then(logger.info)
+    }
 
     logger.info('Email sent')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4661,6 +4661,11 @@ koa-etag@^4.0.0:
   dependencies:
     etag "^1.8.1"
 
+koa-flash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/koa-flash/-/koa-flash-1.0.0.tgz#690f7d10a25130c530dac30b7812d5cf6f74d68d"
+  integrity sha512-UD1abRJv3yNMlq65CLTp848qgASLJJSl0DUTqdR59cfFTXaB/dMq9Z50nehrV/RfHg/tcyq7mQBG6rNl9nL0nw==
+
 koa-is-json@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/koa-is-json/-/koa-is-json-1.0.0.tgz#273c07edcdcb8df6a2c1ab7d59ee76491451ec14"


### PR DESCRIPTION
On registration we weren't requiring users to verify their email addresses. 

We now do this. 

Turns out there was some code missing as well from the `dashboard` with email templates. I've copied those over as well. 

Note that you're going to have to rerun migrations after this PR gets merged. 