### PR TITLE
fix: moved faker require to testConfig.js

### DIFF
--- a/test/baseline/Api.ts/Search.test.js
+++ b/test/baseline/Api.ts/Search.test.js
@@ -1,8 +1,7 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
 
-const { request, expect } = require('../../testConfig')
-const { faker } = require('@faker-js/faker')
+const { request, expect, faker } = require('../../testConfig')
 const { UserGroup, UserGroupType } = require('../../../src/db/models')
 
 describe('Api.ts/search endpoint test', () => {

--- a/test/testConfig.js
+++ b/test/testConfig.js
@@ -3,6 +3,7 @@ const baseURL = `${process.env.APP_HOST}/api/v3`
 const request = require('supertest')(baseURL)
 
 const expect = require('chai').expect
+const { faker } = require('@faker-js/faker')
 
 const TestRedisAdapter = require('../src/auth/redis-adapter')
 
@@ -27,6 +28,7 @@ module.exports = {
   baseURL,
   request,
   expect,
+  faker,
   testUserId,
   testAdminUserId,
   testArtistUserId,


### PR DESCRIPTION
Housekeeping. Moved faker to testConfig.js and revised Search.test.js to get faker from testConfig instead of requiring it directly in the file.