### PR TITLE
feat: initial attempt at starting up worker queues on docker compose up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,10 @@ APP_COOKIE_DOMAIN=stream.resonate.localhost
 APP_KEY="213"
 APP_KEY_2="124"
 APP_EMAIL="resonate.com"
-APP_HOST='http://localhost'
-STATIC_MEDIA_HOST=http://localhost
+APP_HOST='http://localhost:4000'
+STATIC_MEDIA_HOST=http://localhost:4000
 
+NGINX_PORT=3001
 MEDIA_LOCATION=./data/media/
 
 POSTGRES_HOSTNAME=pgsql

--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,9 @@ APP_COOKIE_DOMAIN=stream.resonate.localhost
 APP_KEY="213"
 APP_KEY_2="124"
 APP_EMAIL="resonate.com"
-APP_HOST='http://localhost:4000'
-STREAM_APP_HOST=https://beta.stream.resonate.localhost
-STATIC_MEDIA_HOST=http://localhost:4000
-.
-NGINX_PORT=3001
+APP_HOST='http://localhost'
+STATIC_MEDIA_HOST=http://localhost
+
 MEDIA_LOCATION=./data/media/
 
 POSTGRES_HOSTNAME=pgsql

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Seed the data
 yarn docker:seed:all
 ```
 
-Now go to http://localhost:4000 and you should see the swagger docs!
+Now go to http://localhost/docs and you should see the swagger docs!
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Seed the data
 yarn docker:seed:all
 ```
 
-Now go to http://localhost/docs and you should see the swagger docs!
+Now go to http://localhost:4000/docs and you should see the swagger docs!
 
 ## Tests
 

--- a/background/Dockerfile
+++ b/background/Dockerfile
@@ -1,0 +1,14 @@
+FROM jrottenberg/ffmpeg:5.0-alpine as ffmpeg
+
+FROM node:16-alpine
+
+ENV NODE_APP_DIR=/var/www/api/src
+WORKDIR /var/www/api
+
+COPY . . 
+RUN yarn install --force
+
+# copy ffmpeg bins
+COPY --from=ffmpeg / /
+
+CMD ["node", "src/jobs/queue-worker.js", "run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,29 @@ services:
       - ${MEDIA_LOCATION:-./data/media/}audio:/data/media/audio
       - ${MEDIA_LOCATION:-./data/media/}images:/data/media/images
 
+  background:
+    networks:
+      - api-network
+      - redis-network
+    env_file:
+      - .env
+    build: background
+    # command: /bin/sh -c "yarn && yarn migrate && yarn start:dev"
+    container_name: resonate-background
+    environment:
+      - NODE_ENV=development
+    depends_on:
+      - redis
+      - pgsql
+      - api
+    restart: always
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ./:/var/www/api
+      - ${MEDIA_LOCATION:-./data/media/}incoming:/data/media/incoming
+      - ${MEDIA_LOCATION:-./data/media/}audio:/data/media/audio
+      - ${MEDIA_LOCATION:-./data/media/}images:/data/media/images
+
   pgsql:
     image: postgres:14-alpine
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,12 @@ services:
       - ./data/web-root:/var/www/html
       - ./data/certbot-etc:/etc/letsencrypt
       - ./data/certbot-var:/var/lib/letsencrypt
+      - ${MEDIA_LOCATION:-./data/media/}incoming:/data/media/incoming
+      - ${MEDIA_LOCATION:-./data/media/}audio:/data/media/audio
+      - ${MEDIA_LOCATION:-./data/media/}images:/data/media/images
     build:
       context: ./nginx
-      target: ${IMAGE:-dev-image}
+      target: ${IMAGE:-local-image}
 
     ports:
       - "${NGINX_PORT:-80}:80"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,10 +1,10 @@
 FROM nginx:alpine as base
 
-FROM base as dev-image
+FROM base as local-image
 
 COPY local.dev.conf /etc/nginx/conf.d/default.conf
 
-FROM base as prod-image
+FROM base as stage-image
 
 RUN apk add certbot certbot-nginx
 RUN mkdir /etc/letsencrypt
@@ -12,4 +12,9 @@ RUN mkdir -p /var/www/html
 RUN mkdir -p /var/lib/letsencrypt
 
 COPY dev.resonate.coop.conf /etc/nginx/conf.d/default.conf
+RUN SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME && certbot renew -q" | tee -a /etc/crontab > /dev/null
+
+FROM base as prod-image
+
+COPY prod.resonate.coop.conf /etc/nginx/conf.d/default.conf
 RUN SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME && certbot renew -q" | tee -a /etc/crontab > /dev/null

--- a/nginx/dev.resonate.coop.conf
+++ b/nginx/dev.resonate.coop.conf
@@ -16,27 +16,35 @@ server {
   location @fallback {
     return 301 https://$host$request_uri;
   }
+
+  location /audio {
+    root /data/media;
+  }
 }
 
 server {
-    server_name dev.resonate.coop;
+  server_name dev.resonate.coop;
 
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
 
-    # RSA certificate
-    ssl_certificate /etc/letsencrypt/live/dev.resonate.coop/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dev.resonate.coop/privkey.pem;
+  # RSA certificate
+  ssl_certificate /etc/letsencrypt/live/dev.resonate.coop/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/dev.resonate.coop/privkey.pem;
 
-    include /etc/letsencrypt/options-ssl-nginx.conf;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
 
-    location / {
-        # root /var/www/html;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+  location / {
+    # root /var/www/html;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
 
-        proxy_pass http://api:4000;
-    }
+    proxy_pass http://api:4000;
+  }
+
+  location /audio {
+    root /data/media;
+  }
 }

--- a/nginx/local.dev.conf
+++ b/nginx/local.dev.conf
@@ -1,6 +1,5 @@
 server {
     location /audio {
-        add_header X-debug-message "serving this file" always;
         root /data/media;
     }
 

--- a/nginx/local.dev.conf
+++ b/nginx/local.dev.conf
@@ -1,4 +1,9 @@
 server {
+    location /audio {
+        add_header X-debug-message "serving this file" always;
+        root /data/media;
+    }
+
     location / {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/prod.resonate.coop.conf
+++ b/nginx/prod.resonate.coop.conf
@@ -16,27 +16,35 @@ server {
   location @fallback {
     return 301 https://$host$request_uri;
   }
+
+  location /audio {
+    root /data/media;
+  }
 }
 
 server {
-    server_name prod.resonate.coop;
+  server_name prod.resonate.coop;
 
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
 
-    # RSA certificate
-    ssl_certificate /etc/letsencrypt/live/prod.resonate.coop/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/prod.resonate.coop/privkey.pem;
+  # RSA certificate
+  ssl_certificate /etc/letsencrypt/live/prod.resonate.coop/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/prod.resonate.coop/privkey.pem;
 
-    include /etc/letsencrypt/options-ssl-nginx.conf;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
 
-    location / {
-        # root /var/www/html;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+  location / {
+    # root /var/www/html;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
 
-        proxy_pass http://api:4000;
-    }
+    proxy_pass http://api:4000;
+  }
+
+  location /audio {
+    root /data/media;
+  }
 }

--- a/nginx/prod.resonate.coop.conf
+++ b/nginx/prod.resonate.coop.conf
@@ -1,0 +1,42 @@
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name prod.resonate.coop;
+
+  location ~ /.well-known/acme-challenge {
+    allow all;
+    root /var/www/html;
+  }
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+
+  location @fallback {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+    server_name prod.resonate.coop;
+
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    # RSA certificate
+    ssl_certificate /etc/letsencrypt/live/prod.resonate.coop/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/prod.resonate.coop/privkey.pem;
+
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+
+    location / {
+        # root /var/www/html;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://api:4000;
+    }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -66,3 +66,5 @@ module.exports.STAFF_ROLES_LIST = [
 //   TRACKGROUP_TYPES,
 //   TRACK_STATUS_LIST
 // }
+
+module.exports.apiRoot = '/api/v3'

--- a/src/controllers/artists/routes/index.js
+++ b/src/controllers/artists/routes/index.js
@@ -25,8 +25,11 @@ module.exports = function () {
         include: [
           {
             model: TrackGroup,
+            as: 'trackgroups',
+            required: true,
             include: [{
               model: TrackGroupItem,
+              required: true,
               attributes: ['id', 'index', 'track_id'],
               as: 'items',
               include: [{

--- a/src/controllers/artists/routes/{id}/tracks/index.js
+++ b/src/controllers/artists/routes/{id}/tracks/index.js
@@ -1,3 +1,4 @@
+const { apiRoot } = require('../../../../../constants')
 const { Resonate: sequelize, Track } = require('../../../../../db/models')
 const coverSrc = require('../../../../../util/cover-src')
 
@@ -71,7 +72,7 @@ module.exports = function () {
             },
             artist: item.artist,
             status: item.status === 2 ? 'Free' : 'Paid',
-            url: `https://api.resonate.is/v1/stream/${item.id}`,
+            url: `${process.env.APP_HOST}${apiRoot}/stream/${item.id}`,
             images: variants.reduce((o, key) => {
               const variant = ['small', 'medium', 'large'][variants.indexOf(key)]
 

--- a/src/controllers/index.mjs
+++ b/src/controllers/index.mjs
@@ -67,10 +67,9 @@ import userTracks from './user/tracks/routes/index.js'
 import usersId from './users/routes/{id}/index.js'
 import usersIdPlaylists from './users/routes/{id}/playlists.js'
 
+import { apiRoot as root } from '../constants.js'
+
 const BASE_DATA_DIR = process.env.BASE_DATA_DIR || '/'
-
-const root = '/api/v3'
-
 export const apiRouter = new Router()
 const openApiRouter = new Router()
 

--- a/src/controllers/labels/routes/{id}/releases.js
+++ b/src/controllers/labels/routes/{id}/releases.js
@@ -3,6 +3,7 @@ const { Op } = require('sequelize')
 const slug = require('slug')
 const coverSrc = require('../../../../util/cover-src')
 const ms = require('ms')
+const { apiRoot } = require('../../../../constants')
 
 module.exports = function () {
   const operations = {
@@ -181,7 +182,7 @@ module.exports = function () {
                 creator_id: item.track.creator_id,
                 artist: item.track.artist || nickname,
                 cover: cover,
-                url: `${process.env.STREAM_APP_HOST}/api/v3/user/stream/${item.track.id}`
+                url: `${process.env.APP_HOST}${apiRoot}/user/stream/${item.track.id}`
               }
             }
           })

--- a/src/controllers/playlists/routes/{id}.js
+++ b/src/controllers/playlists/routes/{id}.js
@@ -148,7 +148,7 @@ module.exports = function () {
                     }
                   )
                 }, {}),
-                url: `${process.env.STREAM_APP_HOST}/api/v3/user/stream/${item.track.id}`
+                url: `${process.env.APP_HOST}/api/v3/user/stream/${item.track.id}`
               }
             }
           }),

--- a/src/controllers/stream/index.js
+++ b/src/controllers/stream/index.js
@@ -28,15 +28,20 @@ router.get('/:id', async (ctx, next) => {
 
     const { url: filename } = track
 
-    const alias = `/audio/trim-${filename}.m4a`
+    let alias = `/audio/trim-${filename}.m4a`
+
+    if (track.get('status') === 'free') {
+      alias = `/audio/${filename}.m4a`
+    }
 
     ctx.set({
       Pragma: 'no-cache',
       'Content-Type': 'audio/mp4',
       // 'Content-Length': filesize, TODO if we have a file metadata
-      'Content-Disposition': `inline; filename=${filename}`,
+      // 'Content-Disposition': `inline; filename=${filename}`,
       'X-Accel-Redirect': alias
     })
+    ctx.attachment(filename)
 
     ctx.body = null
   } catch (err) {

--- a/src/controllers/stream/index.js
+++ b/src/controllers/stream/index.js
@@ -1,5 +1,8 @@
 const Koa = require('koa')
 const Router = require('@koa/router')
+const path = require('path')
+const fs = require('fs')
+
 const { File, Track } = require('../../db/models')
 
 const stream = new Koa()
@@ -34,16 +37,25 @@ router.get('/:id', async (ctx, next) => {
       alias = `/audio/${filename}.m4a`
     }
 
-    ctx.set({
-      Pragma: 'no-cache',
-      'Content-Type': 'audio/mp4',
-      // 'Content-Length': filesize, TODO if we have a file metadata
-      // 'Content-Disposition': `inline; filename=${filename}`,
-      'X-Accel-Redirect': alias
-    })
-    ctx.attachment(filename)
+    if (process.env.NODE_ENV !== 'production') {
+      try {
+        ctx.body = fs.createReadStream(path.join(process.env.BASE_DATA_DIR ?? '/', '/data/media', alias))
+      } catch (e) {
+        console.log('error', e)
+        ctx.throw(404, 'Not found')
+      }
+    } else {
+      ctx.set({
+        Pragma: 'no-cache',
+        'Content-Type': 'audio/mp4',
+        // 'Content-Length': filesize, TODO if we have a file metadata
+        // 'Content-Disposition': `inline; filename=${filename}`,
+        'X-Accel-Redirect': alias
+      })
+      ctx.attachment(filename)
 
-    ctx.body = null
+      ctx.body = null
+    }
   } catch (err) {
     ctx.throw(ctx.status, err.message)
   }

--- a/src/controllers/trackgroups/routes/{id}.js
+++ b/src/controllers/trackgroups/routes/{id}.js
@@ -164,7 +164,7 @@ module.exports = function () {
                     }
                   )
                 }, {}),
-                url: `${process.env.STREAM_APP_HOST}/api/v3/user/stream/${item.track.id}`
+                url: `${process.env.APP_HOST}/api/v3/user/stream/${item.track.id}`
               }
             }
           }),

--- a/src/controllers/tracks/routes/{id}.js
+++ b/src/controllers/tracks/routes/{id}.js
@@ -1,6 +1,7 @@
 const { UserGroup, TrackGroup, TrackGroupItem, Track, File } = require('../../../db/models')
 const { Op } = require('sequelize')
 const coverSrc = require('../../../util/cover-src')
+const { apiRoot } = require('../../../constants')
 
 module.exports = function () {
   const operations = {
@@ -123,7 +124,7 @@ module.exports = function () {
             // width, height ?
           },
           status: result.status === 2 ? 'Free' : 'Paid',
-          url: `https://api.resonate.is/v1/stream/${result.id}`,
+          url: `${process.env.APP_HOST}${apiRoot}/stream/${result.id}`,
           images: variants.reduce((o, key) => {
             const variant = ['small', 'medium', 'large'][variants.indexOf(key)]
 

--- a/src/controllers/tracks/services/trackService.js
+++ b/src/controllers/tracks/services/trackService.js
@@ -42,7 +42,7 @@ const trackService = (ctx) => {
           },
           artist: item.artist ? he.decode(item.artist) : null,
           status: item.status === 2 ? 'Free' : 'Paid',
-          url: `${process.env.STREAM_APP_HOST}/api/v3/user/stream/${item.id}`,
+          url: `${process.env.APP_HOST}/api/v3/user/stream/${item.id}`,
           images: variants.reduce((o, key) => {
             const variant = ['small', 'medium', 'large'][variants.indexOf(key)]
 

--- a/src/controllers/user/artists/routes/index.js
+++ b/src/controllers/user/artists/routes/index.js
@@ -86,6 +86,7 @@ module.exports = function () {
         include: [
           {
             model: TrackGroup,
+            as: 'trackgroups',
             include: [{
               model: TrackGroupItem,
               attributes: ['id', 'index', 'track_id'],

--- a/src/controllers/user/authenticate.js
+++ b/src/controllers/user/authenticate.js
@@ -61,6 +61,7 @@ module.exports.authenticate = async (ctx, next) => {
     ctx.throw(401, 'Missing required access token')
   }
 
+  console.log('log', ctx.profile)
   try {
     const user = await findSession(ctx)
 

--- a/src/controllers/user/playlists/routes/{id}/index.js
+++ b/src/controllers/user/playlists/routes/{id}/index.js
@@ -313,7 +313,7 @@ module.exports = function () {
                     }
                   )
                 }, {}),
-                url: `${process.env.STREAM_APP_HOST}/api/v3/user/stream/${item.track.id}`
+                url: `${process.env.APP_HOST}/api/v3/user/stream/${item.track.id}`
               }
             }
           }),

--- a/src/controllers/user/plays/routes/resolve.js
+++ b/src/controllers/user/plays/routes/resolve.js
@@ -26,7 +26,7 @@ module.exports = function () {
         group: [
           sequelize.col('trackId')
         ],
-        logging: console.log,
+        order: [['count', 'DESC']],
         raw: true
       })
 

--- a/src/controllers/user/trackgroups/routes/{id}/index.js
+++ b/src/controllers/user/trackgroups/routes/{id}/index.js
@@ -2,6 +2,7 @@ const { UserGroup, TrackGroup, TrackGroupItem, Track, File } = require('../../..
 const { Op } = require('sequelize')
 const coverSrc = require('../../../../../util/cover-src')
 const { authenticate } = require('../../../authenticate')
+const { apiRoot } = require('../../../../../constants')
 
 module.exports = function () {
   const operations = {
@@ -383,7 +384,7 @@ module.exports = function () {
                     }
                   )
                 }, {}),
-                url: `${process.env.STREAM_APP_HOST}/api/v3/user/stream/${item.track.id}`
+                url: `${process.env.APP_HOST}${apiRoot}/user/stream/${item.track.id}`
               }
             }
           }),

--- a/src/controllers/user/tracks/routes/index.js
+++ b/src/controllers/user/tracks/routes/index.js
@@ -134,7 +134,6 @@ module.exports = function (trackService) {
 
   async function POST (ctx, next) {
     const body = ctx.request.body
-    console.log('this is the post')
     try {
       // const data = Object.assign(body, { creator_id: ctx.profile.id })
       const result = await Track.create(body)

--- a/src/controllers/user/tracks/routes/{id}/index.js
+++ b/src/controllers/user/tracks/routes/{id}/index.js
@@ -3,6 +3,7 @@ const { Op } = require('sequelize')
 const coverSrc = require('../../../../../util/cover-src')
 const { validate } = require('../../../../../schemas/tracks')
 const { authenticate } = require('../../../authenticate')
+const { apiRoot } = require('../../../../../constants')
 
 module.exports = function () {
   const operations = {
@@ -186,7 +187,7 @@ module.exports = function () {
             // width, height ?
           },
           status: result.status === 2 ? 'Free' : 'Paid',
-          url: `https://api.resonate.is/v1/stream/${result.id}`,
+          url: `${process.env.APP_HOST}${apiRoot}/stream/${result.id}`,
           images: variants.reduce((o, key) => {
             const variant = ['small', 'medium', 'large'][variants.indexOf(key)]
 

--- a/src/db/models/resonate/play.js
+++ b/src/db/models/resonate/play.js
@@ -18,7 +18,6 @@ module.exports = (sequelize, DataTypes) => {
     type: {
       type: DataTypes.INTEGER,
       set (type) {
-        console.log('saving', type, types.indexOf(type))
         this.setDataValue('type', types.indexOf(type))
       },
       get () {

--- a/src/db/models/resonate/user_group.js
+++ b/src/db/models/resonate/user_group.js
@@ -61,8 +61,8 @@ module.exports = (sequelize, DataTypes) => {
     UserGroup.hasMany(models.UserGroupMember, { foreignKey: 'memberId', as: 'memberOf' })
     UserGroup.belongsTo(models.UserGroupType, { foreignKey: 'typeId' })
     UserGroup.belongsTo(models.User, { foreignKey: 'ownerId' })
-    UserGroup.hasMany(models.TrackGroup, { foreignKey: 'creatorId' })
-    UserGroup.hasMany(models.Track, { foreignKey: 'creatorId' })
+    UserGroup.hasMany(models.TrackGroup, { foreignKey: 'creatorId', as: 'trackgroups' })
+    UserGroup.hasMany(models.Track, { foreignKey: 'creatorId', as: 'tracks' })
     UserGroup.hasMany(models.UserGroupLink, { as: 'links', foreignKey: 'ownerId' })
   }
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -25,6 +25,7 @@ import errorConfig from './config/error.js'
 import compressConfig from './config/compression.js'
 import sessionConfig from './config/session.js'
 import corsConfig from './config/cors.js'
+import fs from 'fs'
 
 /**
  * Koa apps
@@ -111,6 +112,19 @@ if (process.env.NODE_ENV !== 'production') {
       console.error('e', e)
     }
     await next()
+  })
+
+  staticRouter.get('/audio/:filename', async (ctx, next) => {
+    try {
+      const filename = ctx.request.params.filename
+      // This is a hack for now
+      ctx.body = fs.createReadStream(path.join(BASE_DATA_DIR, '/data/media/audio', filename))
+      next()
+    } catch (e) {
+      console.error('e', e)
+      ctx.throw(500, e)
+    }
+    // await next()
   })
   app.use(staticRouter.routes())
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -32,6 +32,7 @@ import corsConfig from './config/cors.js'
 import user from './controllers/user/index.js'
 import { provider, routes as authRoutes } from './auth/index.js'
 import { apiRouter } from './controllers/index.mjs'
+import { apiRoot } from './constants.js'
 import stream from './controllers/stream/index.js'
 import Router from '@koa/router'
 dotenv.config()
@@ -86,8 +87,8 @@ app.use(apiRouter.routes())
 
 app.use(authRoutes(provider).routes(), authRoutes(provider).allowedMethods({ throw: true }))
 app.use(mount('/', provider.app))
-app.use(mount('/api/v3/stream', stream)) // TODO: put this in the API
-app.use(mount('/api/v3/user', user)) // TODO: put this in the API
+app.use(mount(`${apiRoot}/stream`, stream)) // TODO: put this in the API
+app.use(mount(`${apiRoot}/user`, user)) // TODO: put this in the API
 
 // FIXME: koa-static is currently insecure and out of date.
 // https://github.com/koajs/static/issues/202

--- a/src/jobs/queue-worker.js
+++ b/src/jobs/queue-worker.js
@@ -37,6 +37,7 @@ const workerOptions = {
 
 yargs // eslint-disable-line
   .command('run', 'starts file processing queue', (argv) => {
+    console.log('STARTING WORKER QUEUE')
     audioQueue()
     audioDurationQueue()
     imageQueue()

--- a/test/baseline/Api.ts/Artists.test.js
+++ b/test/baseline/Api.ts/Artists.test.js
@@ -11,7 +11,7 @@ describe('Api.ts/artists endpoint test', () => {
 
   let response = null
 
-  it.only('should GET /artists', async () => {
+  it('should GET /artists', async () => {
     response = await request.get('/artists')
 
     expect(response.status).to.eql(200)

--- a/test/baseline/Api.ts/Artists.test.js
+++ b/test/baseline/Api.ts/Artists.test.js
@@ -11,7 +11,7 @@ describe('Api.ts/artists endpoint test', () => {
 
   let response = null
 
-  it('should GET /artists', async () => {
+  it.only('should GET /artists', async () => {
     response = await request.get('/artists')
 
     expect(response.status).to.eql(200)
@@ -24,7 +24,7 @@ describe('Api.ts/artists endpoint test', () => {
 
     const theData = attributes.data[0]
     //  FIXME: there is 'addressId' and 'AddressId'
-    expect(theData).to.include.keys('id', 'ownerId', 'typeId', 'displayName', 'description', 'shortBio', 'email', 'addressId', 'updatedAt', 'createdAt', 'deletedAt', 'AddressId', 'TrackGroups')
+    expect(theData).to.include.keys('id', 'ownerId', 'typeId', 'displayName', 'description', 'shortBio', 'email', 'addressId', 'updatedAt', 'createdAt', 'deletedAt', 'AddressId', 'trackgroups')
     expect(theData.id).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
     expect(theData.ownerId).to.eql('1c88dea6-0519-4b61-a279-4006954c5d4c')
     expect(theData.typeId).to.eql(1)
@@ -35,10 +35,10 @@ describe('Api.ts/artists endpoint test', () => {
     expect(theData.addressId).to.be.null
     expect(theData.AddressId).to.be.null
 
-    expect(theData.TrackGroups).to.be.an('array')
-    expect(theData.TrackGroups.length).to.eql(3)
+    expect(theData.trackgroups).to.be.an('array')
+    expect(theData.trackgroups.length).to.eql(3)
 
-    const theTG = theData.TrackGroups[0]
+    const theTG = theData.trackgroups[0]
 
     expect(theTG).to.include.keys('composers', 'performers', 'tags', 'id', 'cover', 'title', 'slug', 'type', 'about', 'private', 'display_artist', 'creatorId',
       'release_date', 'download', 'featured', 'enabled', 'updatedAt', 'createdAt', 'deletedAt', 'items')
@@ -262,7 +262,7 @@ describe('Api.ts/artists endpoint test', () => {
 
     expect(theItem.artist).to.eql('matrix')
     expect(theItem.status).to.eql('Paid')
-    expect(theItem.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/' + track.id)
+    expect(theItem.url).to.include('user/stream/' + track.id)
 
     expect(theItem.images).to.be.an('object')
     expect(theItem.images).to.include.keys('small', 'medium')

--- a/test/baseline/Api.ts/Trackgroups.test.js
+++ b/test/baseline/Api.ts/Trackgroups.test.js
@@ -37,7 +37,7 @@ describe('Api.ts/Trackgroups endpoint test', () => {
     expect(theData.creator.id).to.eql('49d2ac44-7f20-4a47-9cf5-3ea5d6ef78f6')
     expect(theData.creator.displayName).to.eql('matrix')
 
-    expect(theData.uri).to.eql('http://localhost:4000/v3/trackgroups/84322e4f-0247-427f-8bed-e7617c3df5ad')
+    expect(theData.uri).to.include('trackgroups/84322e4f-0247-427f-8bed-e7617c3df5ad')
 
     expect(theData.images).to.include.keys('small', 'medium', 'large')
     expect(theData.images.small).to.include.keys('width', 'height')

--- a/test/baseline/Api.ts/Tracks.test.js
+++ b/test/baseline/Api.ts/Tracks.test.js
@@ -63,7 +63,7 @@ describe('Api.ts/track endpoint test', () => {
 
     expect(theData.artist).to.be.null
     expect(theData.status).to.eql('Paid')
-    expect(theData.url).to.eql(`https://beta.stream.resonate.localhost/api/v3/user/stream/${track.id}`)
+    expect(theData.url).to.include(`user/stream/${track.id}`)
 
     expect(theData.images).to.include.keys('small', 'medium')
     expect(theData.images.small).to.include.keys('width', 'height')
@@ -110,7 +110,7 @@ describe('Api.ts/track endpoint test', () => {
 
     expect(theData.artist).to.be.null
     expect(theData.status).to.eql('Paid')
-    expect(theData.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/fcf41302-e549-4ab9-9937-f0bfead5a44f')
+    expect(theData.url).to.include('user/stream/fcf41302-e549-4ab9-9937-f0bfead5a44f')
 
     expect(theData.images).to.be.an('object')
     expect(theData.images).to.include.keys('small', 'medium')
@@ -148,7 +148,7 @@ describe('Api.ts/track endpoint test', () => {
     expect(theData.cover_metadata).to.be.an('object')
 
     expect(theData.status).to.eql('Paid')
-    expect(theData.url).to.eql('https://api.resonate.is/v1/stream/b6d160d1-be16-48a4-8c4f-0c0574c4c6aa')
+    expect(theData.url).to.include('stream/b6d160d1-be16-48a4-8c4f-0c0574c4c6aa')
 
     expect(theData.images).to.include.keys('small', 'medium', 'large')
     expect(theData.images.small).to.include.keys('width', 'height')

--- a/test/baseline/User.ts/User.test.js
+++ b/test/baseline/User.ts/User.test.js
@@ -240,7 +240,7 @@ describe('User.ts/user endpoint test', () => {
     expect(theImages.large.width).to.eql(1500)
     expect(theImages.large.height).to.eql(1500)
 
-    expect(theTrack.url).to.eql('https://beta.stream.resonate.localhost/api/v3/user/stream/44a28752-1101-4e0d-8c40-2c36dc82d035')
+    expect(theTrack.url).to.include('user/stream/44a28752-1101-4e0d-8c40-2c36dc82d035')
 
     // images for the trackgroups
     theImages = theData.images

--- a/test/baseline/User.ts/UserArtist.test.js
+++ b/test/baseline/User.ts/UserArtist.test.js
@@ -25,7 +25,7 @@ describe('User.ts/user artist endpoint test', () => {
     expect(response.status).to.eql(401)
   })
 
-  it('should get user artists', async () => {
+  it.only('should get user artists', async () => {
     response = await request.get('/user/artists').set('Authorization', `Bearer ${testAccessToken}`)
 
     expect(response.status).to.eql(200)
@@ -36,6 +36,7 @@ describe('User.ts/user artist endpoint test', () => {
 
     expect(attributes.data).to.be.an('array')
     expect(attributes.data.length).to.eql(1)
+    expect(attributes.data[0]).to.include.keys('trackgroups')
 
     expect(attributes.count).to.eql(1)
     expect(attributes.pages).to.eql(1)

--- a/test/baseline/User.ts/UserArtist.test.js
+++ b/test/baseline/User.ts/UserArtist.test.js
@@ -25,7 +25,7 @@ describe('User.ts/user artist endpoint test', () => {
     expect(response.status).to.eql(401)
   })
 
-  it.only('should get user artists', async () => {
+  it('should GET user/artists', async () => {
     response = await request.get('/user/artists').set('Authorization', `Bearer ${testAccessToken}`)
 
     expect(response.status).to.eql(200)

--- a/test/baseline/User.ts/UserPlays.test.js
+++ b/test/baseline/User.ts/UserPlays.test.js
@@ -126,10 +126,10 @@ describe('User.ts/user plays endpoint test', () => {
     const { data } = response.body
 
     expect(data.length).to.eql(2)
-    expect(data[1].count).to.eql(2)
-    expect(data[1].trackId).to.eql(track.id)
-    expect(data[0].count).to.eql(1)
-    expect(data[0].trackId).to.eql(track2.id)
+    expect(data[0].count).to.eql(2)
+    expect(data[0].trackId).to.eql(track.id)
+    expect(data[1].count).to.eql(1)
+    expect(data[1].trackId).to.eql(track2.id)
     track.destroy({ force: true })
     track2.destroy({ force: true })
     play.destroy({ force: true })

--- a/test/testConfig.js
+++ b/test/testConfig.js
@@ -1,8 +1,11 @@
 
-const baseURL = `${process.env.APP_HOST}/api/v3`
-const request = require('supertest')(baseURL)
-
+const { apiRoot } = require('../src/constants')
 const expect = require('chai').expect
+
+// We're referencing the URL _inside_ of docker.
+const baseURL = `http://api:4000${apiRoot}`
+
+const request = require('supertest')(baseURL)
 
 const TestRedisAdapter = require('../src/auth/redis-adapter')
 


### PR DESCRIPTION
This will make it so that we'll be using `localhost` when accessing the API and so that worker queues are running in the background. Basically I think this completes the entire pipeline of "upload an audio file" -> "listen to the audio file"

The TL;DR is that if we want nginx to serve the content at `/audio` then we have to a) share it between containers, but also actually access the app through nginx rather than the port forwarding. 

However, node-oidc-provider runs inside of the docker container, so it didn't know about the port to the external world, so the URLs it was generating in `well-known/openid-configuration` were missing the port. So the solution was to not have a port at all. I'm not sure if this is ultimately a bug with node-oidc-provider and if that should be fixed, but I feel like it's outside of its control where it's grabbing the URL from. 

To test it out, pull down the branch

```
git fetch --all
git checkout worker-queues-on-startup
```

Then update `.env` to match the `.env.example`.

```
docker-compose up
```

Go to `http://localhost/docs`

For complete testing, also start up beam.

```
git pull origin main
```

Then go to `localhost:8080`

You should be able to log in with `artist@admin.com` and `test1234`. Then go to `localhost:8080/manage`, click on a trackgroup, use the pop up to add a track with a **flac** file. Then once it's uploaded click play on the track file. 