### PR TITLE
feat: add userPlays and userFavorited to tracks

### DIFF
--- a/src/controllers/artists/routes/index.js
+++ b/src/controllers/artists/routes/index.js
@@ -1,10 +1,11 @@
 const models = require('../../../db/models')
+const { loadProfileIntoContext } = require('../../user/authenticate')
 const artistService = require('../artistService')
 const { UserGroup, TrackGroup, TrackGroupItem, Track } = models
 
 module.exports = function () {
   const operations = {
-    GET
+    GET: [loadProfileIntoContext, GET]
   }
 
   async function GET (ctx, next) {
@@ -37,7 +38,7 @@ module.exports = function () {
               separate: true,
               order: [['index', 'ASC']],
               include: [{
-                model: Track,
+                model: Track.scope({ method: ['loggedIn', ctx.profile?.id] }),
                 as: 'track'
               }]
             }]

--- a/src/controllers/playlists/routes/{id}.js
+++ b/src/controllers/playlists/routes/{id}.js
@@ -37,7 +37,7 @@ module.exports = function () {
     }
 
     try {
-      const result = await Playlist.scope('items').findOne({
+      const result = await Playlist.scope({ method: ['items', ctx.profile?.id] }).findOne({
         attributes: [
           'about',
           'cover',

--- a/src/controllers/trackgroups/routes/{id}.js
+++ b/src/controllers/trackgroups/routes/{id}.js
@@ -2,10 +2,11 @@ const { UserGroup, TrackGroup, TrackGroupItem, Track, File } = require('../../..
 const { Op } = require('sequelize')
 const ms = require('ms')
 const trackgroupService = require('../services/trackgroupService')
+const { loadProfileIntoContext } = require('../../user/authenticate')
 
 module.exports = function () {
   const operations = {
-    GET,
+    GET: [loadProfileIntoContext, GET],
     parameters: [
       {
         name: 'id',
@@ -76,14 +77,9 @@ module.exports = function () {
             attributes: ['id', 'index'],
             as: 'items',
             include: [{
-              model: Track,
-              attributes: ['id', 'creatorId', 'cover_art', 'title', 'album', 'artist', 'duration', 'status'],
+              model: Track.scope('public', { method: ['loggedIn', ctx.profile?.id] }),
+              attributes: ['id', 'creatorId', 'title', 'album', 'artist', 'duration', 'status'],
               as: 'track',
-              where: {
-                status: {
-                  [Op.in]: [0, 2, 3]
-                }
-              },
               include: [
                 {
                   model: File,

--- a/src/controllers/tracks/routes/{id}.js
+++ b/src/controllers/tracks/routes/{id}.js
@@ -1,10 +1,10 @@
 const { Track } = require('../../../db/models')
-const { Op } = require('sequelize')
 const trackService = require('../services/trackService')
+const { loadProfileIntoContext } = require('../../user/authenticate')
 
 module.exports = function () {
   const operations = {
-    GET,
+    GET: [loadProfileIntoContext, GET],
     parameters: [
       {
         name: 'id',
@@ -20,12 +20,9 @@ module.exports = function () {
   async function GET (ctx, next) {
     if (await ctx.cashed?.()) return
     try {
-      const result = await Track.scope('details').findOne({
+      const result = await Track.scope('details', 'public', { method: ['loggedIn', ctx.profile?.id] }).findOne({
         where: {
-          id: ctx.params.id,
-          status: {
-            [Op.in]: [0, 2, 3]
-          }
+          id: ctx.params.id
         },
         attributes: [
           'id',

--- a/src/controllers/tracks/services/trackService.js
+++ b/src/controllers/tracks/services/trackService.js
@@ -34,6 +34,8 @@ const trackService = (ctx) => {
       year: item.year,
       status: item.status,
       creator: item.creator,
+      userPlays: item.plays ? item.plays.length : undefined,
+      userFavorited: item.favorites ? item.favorites.length === 1 : undefined,
       // FIXME: artist is legacy stuff, we probably need to migrate it.
       artist: item.artist ? he.decode(item.artist) : null,
       url: `${process.env.APP_HOST}${apiRoot}/user/stream/${item.id}`,

--- a/src/db/models/resonate/playlist.js
+++ b/src/db/models/resonate/playlist.js
@@ -83,7 +83,7 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'Playlist',
     tableName: 'playlists',
     scopes: {
-      items: () => ({
+      items: (userId) => ({
         // order: [
         //   [{ model: sequelize.models.PlaylistItem, as: 'items' }, 'index', 'asc']
         // ],
@@ -95,14 +95,9 @@ module.exports = (sequelize, DataTypes) => {
           order: [['index', 'ASC']],
           as: 'items',
           include: [{
-            model: sequelize.models.Track,
+            model: sequelize.models.Track.scope('public', { method: ['loggedIn', userId] }),
             attributes: ['id', 'creatorId', 'title', 'album', 'artist', 'duration', 'status'],
             as: 'track',
-            where: {
-              status: {
-                [Op.in]: [0, 2, 3]
-              }
-            },
             include: [
               {
                 model: sequelize.models.File,

--- a/test/baseline/playlists/playlists.test.js
+++ b/test/baseline/playlists/playlists.test.js
@@ -2,12 +2,15 @@
 /* eslint-env mocha */
 
 const ResetDB = require('../../ResetDB')
-const { request, expect, testArtistId, testUserId } = require('../../testConfig')
-const { Playlist, PlaylistItem, Track } = require('../../../src/db/models')
+const MockAccessToken = require('../../MockAccessToken')
+const { request, expect, testArtistId, testAccessToken, testUserId, testArtistUserId } = require('../../testConfig')
+const { Playlist, PlaylistItem, Track, Play, Favorite } = require('../../../src/db/models')
 const { faker } = require('@faker-js/faker')
 
 describe('/playlists endpoint test', () => {
   ResetDB()
+  MockAccessToken(testUserId)
+
   let response = null
 
   it('should GET /playlists', async () => {
@@ -61,5 +64,59 @@ describe('/playlists endpoint test', () => {
     await playlist.destroy({ force: true })
     await track2.destroy({ force: true })
     await pi.destroy({ force: true })
+  })
+
+  it('should GET playlists/:id for logged in user', async () => {
+    const track = await Track.create({
+      title: faker.animal.cat(),
+      creatorId: testArtistId,
+      status: 'paid'
+    })
+    const playlist = await Playlist.create({
+      title: faker.animal.dog(),
+      creatorId: testArtistId,
+      cover: faker.datatype.uuid(),
+      type: 'single',
+      enabled: true,
+      private: false
+    })
+    const tgi = await PlaylistItem.create({
+      playlistId: playlist.id,
+      trackId: track.id,
+      index: 1
+    })
+    const play = await Play.create({
+      userId: testUserId,
+      trackId: track.id
+    })
+    const play2 = await Play.create({
+      userId: testUserId,
+      trackId: track.id
+    })
+    const play3 = await Play.create({
+      userId: testArtistUserId,
+      trackId: track.id
+    })
+    const favorite = await Favorite.create({
+      userId: testUserId,
+      trackId: track.id,
+      type: true
+    })
+
+    response = await request.get(`/playlists/${playlist.id}`)
+      .set('Authorization', `Bearer ${testAccessToken}`)
+
+    const { data } = response.body
+
+    expect(data.items[0].track.userPlays).to.eql(2)
+    expect(data.items[0].track.userFavorited).to.eql(true)
+
+    await track.destroy({ force: true })
+    await playlist.destroy({ force: true })
+    await tgi.destroy({ force: true })
+    await play.destroy({ force: true })
+    await play2.destroy({ force: true })
+    await play3.destroy({ force: true })
+    await favorite.destroy({ force: true })
   })
 })


### PR DESCRIPTION
To do with #152 . 

If a user is logged in, add details to a track so that we return how many plays a user has for a track and whether they've favorited it. This should reduce the number of requests to the API significantly. 